### PR TITLE
Don't squash EXTRA_ARGS when --target Mono is set

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -231,7 +231,7 @@ case $target in
     Mono)
         setMonoDir
         CONFIGURATION=Debug-MONO
-        EXTRA_ARGS="/p:CscToolExe=mcs /p:CscToolPath=$MONO_BIN_DIR"
+        EXTRA_ARGS="$EXTRA_ARGS /p:CscToolExe=mcs /p:CscToolPath=$MONO_BIN_DIR"
         RUNTIME_HOST_ARGS="--debug"
         ;;
     *)


### PR DESCRIPTION
We need to set `/p:RuntimeSystem=` on Linux, but this value is set on line 204 then overwritten with something else on line 234