### PR TITLE
Catch a possible exception when trying to resolve from HKLM.

### DIFF
--- a/src/XMakeTasks/AssemblyFolder.cs
+++ b/src/XMakeTasks/AssemblyFolder.cs
@@ -113,18 +113,21 @@ namespace Microsoft.Build.Tasks
         {
             s_assemblyFolders = new Hashtable(StringComparer.OrdinalIgnoreCase);
 
-            // Populate the table of assembly folders.
-            AddFoldersFromRegistryKey
-            (
-                @"SOFTWARE\Microsoft\.NETFramework\AssemblyFolders",
-                s_assemblyFolders
-            );
+            if (NativeMethodsShared.IsWindows)
+            {
+                // Populate the table of assembly folders.
+                AddFoldersFromRegistryKey
+                (
+                    @"SOFTWARE\Microsoft\.NETFramework\AssemblyFolders",
+                    s_assemblyFolders
+                );
 
-            AddFoldersFromRegistryKey
-            (
-                @"SOFTWARE\Microsoft\VisualStudio\8.0\AssemblyFolders",
-                s_assemblyFolders
-            );
+                AddFoldersFromRegistryKey
+                (
+                    @"SOFTWARE\Microsoft\VisualStudio\8.0\AssemblyFolders",
+                    s_assemblyFolders
+                );
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
On Mono, RegistryKey.OpenSubKey will attempt to create the registry hive's on-disk folder, if it doesn't exist. For HKLM, that folder is in /etc/mono/registry - but only `root` has write access to /etc, so the constructor throws an exception. We can just try{}catch{} this, since we can't risk calling the constructor, and if it throws then it doesn't exist (so obviously there's nothing of value inside).