### PR TITLE
Assume `ubuntu.14.04` not `ubuntu`, the latter doesn't exist.

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -125,7 +125,7 @@ get_current_linux_name() {
     fi
 
     # Cannot determine Linux distribution, assuming Ubuntu 14.04.
-    echo "ubuntu"
+    echo "ubuntu.14.04"
     return 0
 }
 


### PR DESCRIPTION
This fixes the build on _most_ Linux distributions which fail OS detection (released after April 2014, so able to run binaries compiled for Ubuntu 14.04)