### PR TITLE
Assume `ubuntu.14.04` not `ubuntu`, the latter doesn't exist. (#7)

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -129,7 +129,7 @@ get_current_linux_name() {
     fi
 
     # Cannot determine Linux distribution, assuming Ubuntu 14.04.
-    echo "ubuntu"
+    echo "ubuntu.14.04"
     return 0
 }
 


### PR DESCRIPTION
(cherry picked from commit 199c93cb28aa09cb1badedb49cf58f8179460171)