### PR TITLE
[Mono] Use NuGet fsc for .netcore compilation

### DIFF
--- a/sdks/FSharp.NET.Sdk/Sdk/Sdk.props
+++ b/sdks/FSharp.NET.Sdk/Sdk/Sdk.props
@@ -8,8 +8,6 @@
     <_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
 
     <DontRunFscWithDotnet>true</DontRunFscWithDotnet>
-    <FscToolExe>fsc.exe</FscToolExe>
-    <FscToolPath>$(MSBuildToolsPath)..\..\..\fsharp</FscToolPath>
   </PropertyGroup>
 
 </Project>

--- a/sdks/FSharp.NET.Sdk/Sdk/Sdk.targets
+++ b/sdks/FSharp.NET.Sdk/Sdk/Sdk.targets
@@ -23,11 +23,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Normal commands -->
     <LanguageTargets Condition=" '$(FSharpLanguageTargets)' != '' ">$(FSharpLanguageTargets)</LanguageTargets>
 
-
-    <!-- Set this here, because FscTool* properties get unconditionally set
-	 in the Sdk, so we want to override them -->
-    <FscToolExe>fsc.exe</FscToolExe>
-    <FscToolPath>$(MSBuildToolsPath)\..\..\..\fsharp</FscToolPath>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Since F# SDK 1.0.3, it is no longer necessary to use the Mono fsc to
compile. This should make builds more deterministic across different platforms.

Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=55626