### PR TITLE
remove unused property

### DIFF
--- a/sdks/FSharp.NET.Sdk/Sdk/Sdk.props
+++ b/sdks/FSharp.NET.Sdk/Sdk/Sdk.props
@@ -6,8 +6,6 @@
     <!-- _DebugFileExt is not an upstream msbuild feature yet -->
     <_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
     <_DebugFileExt Condition="'$(_DebugFileExt)' == ''">.mdb</_DebugFileExt>
-
-    <DontRunFscWithDotnet>true</DontRunFscWithDotnet>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
the `DontRunFscWithDotnet` is not used anymore with `FSharp.NET.Sdk` >= 1.0.3
The `fsc` is executed with or without `dotnet` based on file extension of `FscToolExe` property

/cc @nosami @radical
