### PR TITLE
Explicitly use #!/bin/bash for install script

### DIFF
--- a/install-mono-prefix.sh
+++ b/install-mono-prefix.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 set -x
 if [ $# -ne 1 ]; then


### PR DESCRIPTION
One of the installation file copies uses non-POSIX wildcard matching semantics, which breaks on any system where /bin/sh is not Bash or similar (e.g. most Debian derivatives):

```
cp: cannot stat 'bin/Release-MONO/AnyCPU/Unix/Unix_Deployment/MSBuild.{dll,pdb,rsp}*': No such file or directory
```

Forcing Bash avoids the issue. The alternative approach is reworking https://github.com/mono/msbuild/blob/d15.3/install-mono-prefix.sh#L41