### PR TITLE
Disable ReferenceAssembly generation support, only for 15.3

### DIFF
--- a/src/Tasks/Microsoft.Common.CurrentVersion.targets
+++ b/src/Tasks/Microsoft.Common.CurrentVersion.targets
@@ -161,7 +161,8 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     <_DocumentationFileProduced Condition="'$(DocumentationFile)'==''">false</_DocumentationFileProduced>
 
     <!-- Whether or not a reference assembly is produced. -->
-    <ProduceReferenceAssembly Condition="'$(ProduceReferenceAssembly)' == ''">false</ProduceReferenceAssembly>
+    <_OriginalProduceReferenceAssembly>$(ProduceReferenceAssembly)</_OriginalProduceReferenceAssembly>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OutputPath)' == '' ">
@@ -4079,7 +4080,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </Copy>
 
     <!-- Copy the reference assembly build product (.dll or .exe). -->
-    <CopyRefAssembly
+    <!-- CopyRefAssembly
         SourcePath="@(IntermediateRefAssembly)"
         DestinationPath="$(TargetRefPath)"
         Condition="'$(ProduceReferenceAssembly)' == 'true' and '$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)' != 'true'"
@@ -4088,7 +4089,10 @@ Copyright (C) Microsoft Corporation. All rights reserved.
       <Output TaskParameter="DestinationPath" ItemName="ReferenceAssembly"/>
       <Output TaskParameter="DestinationPath" ItemName="FileWrites"/>
 
-    </CopyRefAssembly>
+    </CopyRefAssembly -->
+    <Warning
+	    Text="Ignoring %24(ProduceReferenceAssembly) as generation of reference assemblies is not supported on Mono yet. You can set it conditionally as &lt;ProduceReferenceAssembly Condition=&quot;'%24(MSBuildRuntimeType)' != 'Mono'&quot;&gt;true&lt;/ProduceReferenceAssembly&gt;"
+	    Condition="'$(_OriginalProduceReferenceAssembly)' == 'true'" />
 
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; @(MainAssembly->'%(FullPath)')" Condition="'$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)'!='true'" />
 


### PR DESCRIPTION
- msbuild 15.3 has support for generating Reference assemblies[1],
  triggered by `$(ProduceReferenceAssembly)` which is never set to true
  by any msbuild targets or IDE(VS*) project templates.

- It is strictly an opt-in feature, so the user has to set this property
  explicitly in their project files. If the user has this property set,
  then they would see:

	/Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/msbuild/15.0/bin/Microsoft.Common.CurrentVersion.targets(4082,5):
		error MSB4062: The "Microsoft.CodeAnalysis.BuildTasks.CopyRefAssembly" task could not be loaded from the assembly /Library/Frameworks/Mono.framework/Versions/5.2.0/lib/mono/msbuild/15.0/bin/Roslyn/Microsoft.Build.Tasks.CodeAnalysis.dll.  Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.

Reasons:

- The support for this feature is partially in msbuild's
  Microsoft.Common*targets and rest in Roslyn's `csc.exe`, and the
  corresponding build task assemblies and targets.

- Mono's msbuild is bundling the C# and VB tasks+targets as-is from the
  repository, which is using 2.0.0*. But the feature was introduced in
  Roslyn 2.3.0* .

- Mono bundles a newer csc.exe (2.3.0*).

- So, effectively, there is a mismatch - newer csc.exe but older
  tasks+targets. To be specific, the `CopyRefAssembly` task is expected
  to be in Microsoft.Build.Tasks.CodeAnalysis.dll , but that was added
  in 2.3.0, so we don't have it in mono/msbuild.

- Reference assemblies are not being generated anyway, because C#
  targets/tasks implement that part.

- It is too late to fix this for 15.3 and considering that this is an
  opt-in feature, not critical enough to force it in.

Instead:

- we disable the only `CopyRefAssembly` usage in msbuild targets

- and we emit a warning and suggest that the user set the property
  conditionally, so that they can continue using it on !mono :

	```<ProduceReferenceAssembly Condition="'$(MSBuildRuntimeType)' != 'Mono'">true</ProduceReferenceAssembly>```

- Reference assemblies are not being generated anyway, because C#
  targets/tasks implement that part. So, we don't need to touch other
  reference assembly related properties, in the interest of getting the
  minimum fix.

bxc: https://bugzilla.xamarin.com/show_bug.cgi?id=58228

----

1. https://github.com/dotnet/roslyn/blob/master/docs/features/refout.md