### PR TITLE
Copy task: Use file sizes too, for skip checks, on !windows

### DIFF
--- a/src/Tasks.UnitTests/Copy_Tests.cs
+++ b/src/Tasks.UnitTests/Copy_Tests.cs
@@ -440,7 +440,6 @@ namespace Microsoft.Build.UnitTests
          * have different dates or sizes.
          */
         [Fact]
-        [Trait("Category", "mono-osx-failing")]
         [Trait("Category", "netcore-osx-failing")]
         [Trait("Category", "netcore-linux-failing")]
         public void DoCopyOverDifferentFile()

--- a/src/Tasks/FileState.cs
+++ b/src/Tasks/FileState.cs
@@ -165,6 +165,7 @@ namespace Microsoft.Build.Tasks
                             var fileInfo = new FileInfo(_filename);
                             IsReadOnly = fileInfo.IsReadOnly;
                             LastWriteTimeUtc = fileInfo.LastWriteTimeUtc;
+                            Length = fileInfo.Length;
                         }
                     }
                 }


### PR DESCRIPTION
Given two files with differ only in file size, and we have ..

    <Copy SourceFiles="first.txt" DestinationFiles="second.txt"
        SkipUnchangedFiles="true" />

.. this skips the file even though their sizes differ.

Turns out, FileState.FileDirInfo does not read the Length of the file
for !windows, which means that the `Copy` tasks just treats the files as
zero-sized, for checking whether to skip or not.

This manifested as bug https://bugzilla.xamarin.com/show_bug.cgi?id=58280

Of course, we have tests for this kind of thing, but they are disabled
and fixing this issue fixes these tests too:

      Microsoft.Build.UnitTests.CopyNotHardLink_Tests.DoCopyOverDifferentFile
      Microsoft.Build.UnitTests.CopySymbolicLink_Tests.DoCopyOverDifferentFile
      Microsoft.Build.UnitTests.CopyHardLink_Tests.DoCopyOverDifferentFile