### PR TITLE
[mono] Don't copy Roslyn/ to install dir, since we will get it OOB

### DIFF
--- a/install-mono-prefix.sh
+++ b/install-mono-prefix.sh
@@ -44,7 +44,7 @@ cp $MSBUILD_OUT_DIR/Microsoft.*.{props,targets} ${DESTDIR}${MSBUILD_INSTALL_BIN_
 cp $MSBUILD_OUT_DIR/Workflow* ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}
 cp $MSBUILD_OUT_DIR/*.dll ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}
 
-cp -r $MSBUILD_OUT_DIR/Roslyn ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}
+#cp -r $MSBUILD_OUT_DIR/Roslyn ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}
 cp -r $MSBUILD_OUT_DIR/Extensions ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}
 
 # Deploy files meant for the default $(MSBuildExtensionsPath)
@@ -58,7 +58,7 @@ rm ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}/*UnitTests*
 rm ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}/*xunit*
 rm ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}/NuGet*
 rm ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}/System.Runtime.InteropServices.RuntimeInformation.dll
-rm ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}/Roslyn/csc.exe*
+#rm ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}/Roslyn/csc.exe*
 
 FILES="\
     Dependency.dll \


### PR DESCRIPTION
Roslyn's csc.exe and the corresponding
Microsoft.Build.Tasks.CodeAnalysis.dll need to be in sync. But the final
deployed Mono would have the former from Mono, and the latter from
msbuild. And this can get out of sync. As it did and we had to
workaround in 7a4c5c631ddc82b7f6682ce7c09693538d778eac
(https://github.com/mono/msbuild/pull/19).

Now we stop copying the `Roslyn/` folder at all, and instead that gets
populated by Mono installation, when it installs csc.exe too.