### PR TITLE
Fix TargetFrameworkRootPathFallback when MSBuild API is used in different process

### DIFF
--- a/src/Shared/FrameworkLocationHelper.cs
+++ b/src/Shared/FrameworkLocationHelper.cs
@@ -1046,11 +1046,8 @@ namespace Microsoft.Build.Shared
 
             if (ToolsetConfigurationReaderHelpers.ConfigurationFileMayHaveToolsets())
             {
-                Configuration configuration = BuildEnvironmentHelper.Instance.RunningTests
-                                                  ? ConfigurationManager.OpenExeConfiguration(
-                                                      BuildEnvironmentHelper.Instance.CurrentMSBuildExePath)
-                                                  : ConfigurationManager.OpenExeConfiguration(
-                                                      ConfigurationUserLevel.None);
+                Configuration configuration = ConfigurationManager.OpenExeConfiguration(
+                                                BuildEnvironmentHelper.Instance.CurrentMSBuildExePath);
 
                 configurationSection = ToolsetConfigurationReaderHelpers.ReadToolsetConfigurationSection(configuration);
             }


### PR DESCRIPTION
When reading the TargetFrameworkRootPathFallback from the app.config, we need use the configuration file from the current MSBuild Exe Path rather than the one from the current process. This is consistent with the behavior of `ToolsetConfigurationReaderHelpers.ConfigurationFileMayHaveToolsets()`.

This addresses the particular scenario of using MSBuild as an API within another application (in my case OmniSharp).

cc @radical 