### PR TITLE
[mono] Add suport for denied assemblies, fixed bxc#56682

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -11,6 +11,7 @@
     <ProjectWithoutConfiguration Include="build\dirs.proj" />
     <ProjectWithoutConfiguration Include="src\dirs.proj" />
     <ProjectWithoutConfiguration Include="Samples\dirs.proj" Condition="'$(BuildSamples)'!='false'" />
+    <ProjectWithoutConfiguration Include="mono\tasks\build.csproj" Condition="'$(MonoBuild)'=='true'" />
     <ProjectWithoutConfiguration Include="mono\facades\build.proj" Condition="'$(MonoBuild)'=='true'" />
   </ItemGroup>
 

--- a/install-mono-prefix.sh
+++ b/install-mono-prefix.sh
@@ -44,6 +44,9 @@ cp $MSBUILD_OUT_DIR/Microsoft.*.{props,targets} ${DESTDIR}${MSBUILD_INSTALL_BIN_
 cp $MSBUILD_OUT_DIR/Workflow* ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}
 cp $MSBUILD_OUT_DIR/*.dll ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}
 
+# this needs to be in extensions path only
+mv ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}/Mono.Build.Tasks.* ${DESTDIR}${XBUILD_DIR}
+
 #cp -r $MSBUILD_OUT_DIR/Roslyn ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}
 cp -r $MSBUILD_OUT_DIR/Extensions ${DESTDIR}${MSBUILD_INSTALL_BIN_DIR}
 

--- a/mono/ExtensionsPath-ToolsVersion/Microsoft.Common.targets/ImportAfter/Microsoft.Common.Mono.After.targets
+++ b/mono/ExtensionsPath-ToolsVersion/Microsoft.Common.targets/ImportAfter/Microsoft.Common.Mono.After.targets
@@ -1,0 +1,36 @@
+﻿<!--
+***********************************************************************************************
+Microsoft.Common.Mono.After.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (C) Microsoft Corporation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <UsingTask TaskName="Mono.Build.Tasks.FilterDeniedAssemblies" AssemblyFile="$(MSBuildExtensionsPath)\Mono.Build.Tasks.dll" />
+
+    <PropertyGroup>
+        <FilterDeniedAssemblies Condition="$(FilterDeniedAssemblies) == ''">false</FilterDeniedAssemblies>
+    </PropertyGroup>
+
+    <Target
+        Name="FilterDeniedAssemblyReferences"
+        BeforeTargets="ResolveAssemblyReferences"
+        Condition="'$(FilterDeniedAssemblies)' == 'true'">
+
+        <FilterDeniedAssemblies References="@(Reference)" SearchPaths="$(TargetFrameworkDirectory);$(DesignTimeFacadeDirectories)">
+            <Output TaskParameter="DeniedReferencesThatCouldNotBeFixed" ItemName="DeniedReferencesThatCouldNotBeFixed" />
+            <Output TaskParameter="FilteredReferences" ItemName="FilteredReferences" />
+        </FilterDeniedAssemblies>
+
+        <ItemGroup>
+            <Reference Remove="@(Reference)" />
+            <Reference Include="@(FilteredReferences)" />
+        </ItemGroup>
+    </Target>
+
+</Project>

--- a/mono/tasks/FilterDeniedAssemblies.cs
+++ b/mono/tasks/FilterDeniedAssemblies.cs
@@ -1,0 +1,182 @@
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.IO;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Linq;
+using System.Text;
+
+namespace Mono.Build.Tasks
+{
+    public class FilterDeniedAssemblies : Task
+    {
+        static string s_deniedListFilename = "deniedAssembliesList.txt";
+
+        static string s_deniedListFullPath => Path.Combine(
+                                                    Path.GetDirectoryName(typeof (FilterDeniedAssemblies).Assembly.Location),
+                                                    s_deniedListFilename);
+
+        // Using the valueFactory overload to get exception caching
+        static Lazy<ExclusionDB> s_db = new Lazy<ExclusionDB>(() => new ExclusionDB(s_deniedListFullPath));
+
+        static bool s_haveWarnedAboutMissingList = false;
+
+        public override bool Execute ()
+        {
+            FilteredReferences = References;
+
+            if (!File.Exists (s_deniedListFullPath)) {
+                if (!s_haveWarnedAboutMissingList) {
+                    Log.LogWarning(null, "MSB3911", null,BuildEngine.ProjectFileOfTaskNode, BuildEngine.LineNumberOfTaskNode, BuildEngine.ColumnNumberOfTaskNode, 0, 0,
+                                    $"INTERNAL WARNING: Could not find the list of denied assemblies at {s_deniedListFullPath}. Please file a bug report at https://bugzilla.xamarin.com .");
+
+                    s_haveWarnedAboutMissingList = true;
+                }
+
+                return !Log.HasLoggedErrors;
+            }
+
+            if (s_db.Value.Empty) {
+                // nothing to filter!
+                return !Log.HasLoggedErrors;
+            }
+
+            var deniedReferencesNotFixedItemsList = new List<ITaskItem> ();
+            var filteredItems = new List<ITaskItem> ();
+
+            foreach (var referenceItem in References) {
+                // Try to find the path corresponding to a reference
+                // - item Include might itself be a path
+                // - or it might have a HintPath with the path
+                bool foundInHintPath = false;
+                var assemblyPathFromReference = referenceItem.GetMetadata("FullPath");
+
+                if (!File.Exists (assemblyPathFromReference)) {
+                    var hintPath = referenceItem.GetMetadata ("HintPath");
+                    if (!String.IsNullOrEmpty (hintPath)) {
+                        assemblyPathFromReference = Path.GetFullPath (hintPath);
+                        if (!File.Exists(assemblyPathFromReference))
+                            assemblyPathFromReference = null;
+                        else
+                            foundInHintPath = true;
+                    }
+                }
+
+                if (assemblyPathFromReference != null && s_db.Value.IsDeniedAssembly (assemblyPathFromReference)) {
+                    referenceItem.SetMetadata ("DeniedAssemblyPath", assemblyPathFromReference);
+
+                    // Try to find the "safe" assembly under @SearchPaths, and update the reference
+
+                    var assemblyFilename = Path.GetFileName (assemblyPathFromReference);
+                    var safeAssemblyFilePath = SearchPaths
+                                                .Select (d => Path.Combine (d, assemblyFilename))
+                                                .Where (f => File.Exists (f))
+                                                .FirstOrDefault ();
+
+                    if (safeAssemblyFilePath != null) {
+                        if (foundInHintPath)
+                            referenceItem.SetMetadata ("HintPath", safeAssemblyFilePath);
+                        else
+                            referenceItem.ItemSpec = safeAssemblyFilePath;
+
+                        referenceItem.SetMetadata ("FixedDeniedAssemblyPath", "true");
+
+                        Log.LogMessage (MessageImportance.Low, $"Changed the denied (windows specific) assembly reference path from {assemblyPathFromReference} to the safe assembly path {safeAssemblyFilePath}.");
+                    } else {
+                        Log.LogWarning(null, "MSB3912", null, BuildEngine.ProjectFileOfTaskNode, BuildEngine.LineNumberOfTaskNode, BuildEngine.ColumnNumberOfTaskNode, 0, 0,
+                                        $"INTERNAL WARNING: Could not find the replacement assembly ({assemblyFilename}) for the Windows specific reference {assemblyPathFromReference}." +
+                                        " Please file a bug report at https://bugzilla.xamarin.com .");
+
+                        referenceItem.SetMetadata ("FixedDeniedAssemblyPath", "false");
+                        deniedReferencesNotFixedItemsList.Add (referenceItem);
+                    }
+                }
+
+                filteredItems.Add (referenceItem);
+            }
+
+            DeniedReferencesThatCouldNotBeFixed = deniedReferencesNotFixedItemsList.ToArray ();
+            FilteredReferences = filteredItems.ToArray ();
+
+            return !Log.HasLoggedErrors;
+        }
+
+        [Required]
+        public ITaskItem[]  References { get; set; }
+
+        [Required]
+        public string[]     SearchPaths { get; set; }
+
+        [Output]
+        public ITaskItem[]  DeniedReferencesThatCouldNotBeFixed { get; set; }
+
+        [Output]
+        public ITaskItem[]  FilteredReferences { get; set; }
+    }
+
+    class ExclusionDB
+    {
+        public HashSet<string>  ExclusionSet;
+        public List<string>     ExclusionNamesList;
+        public bool             Empty;
+
+        public ExclusionDB(string deniedListFilePath)
+        {
+            Empty = true;
+            ExclusionSet = new HashSet<string>();
+            ExclusionNamesList = new List<string>();
+
+            if (!File.Exists (deniedListFilePath))
+                throw new FileNotFoundException($"Could not find the list of denied assemblies at {deniedListFilePath}", deniedListFilePath);
+
+            var lines = File.ReadAllLines(deniedListFilePath);
+            foreach (var line in lines) {
+                var comma = line.IndexOf (",");
+                if (comma < 0)
+                    continue;
+
+                var filename = line.Substring (0, comma).Trim ();
+                if (filename.Length > 0) {
+                    ExclusionSet.Add (line);
+                    ExclusionNamesList.Add (filename);
+                }
+            }
+
+            Empty = ExclusionNamesList.Count == 0;
+        }
+
+        public bool IsDeniedAssembly (string assemblyFullPath)
+        {
+            var assemblyFilename = Path.GetFileName (assemblyFullPath);
+
+            return ExclusionNamesList.Contains (assemblyFilename) &&
+                    ExclusionSet.Contains (CreateKeyForAssembly (assemblyFullPath));
+        }
+
+        static string CreateKeyForAssembly (string fullpath)
+        {
+            if (String.IsNullOrEmpty (fullpath) || !File.Exists (fullpath))
+                return String.Empty;
+
+            var filename = Path.GetFileName (fullpath);
+            Version ver;
+
+            using (var stream = File.OpenRead(fullpath))
+            using (var peFile = new PEReader(stream))
+            {
+                var metadataReader = peFile.GetMetadataReader();
+
+                var entry = metadataReader.GetAssemblyDefinition();
+                ver = entry.Version;
+                var guid = metadataReader.GetGuid(metadataReader.GetModuleDefinition().Mvid);
+
+                var id = guid.ToString (null, CultureInfo.InvariantCulture).ToUpperInvariant ();
+                return $"{filename},{id},{ver.Major},{ver.Minor},{ver.Build},{ver.Revision}";
+            }
+        }
+    }
+}

--- a/mono/tasks/build.csproj
+++ b/mono/tasks/build.csproj
@@ -1,0 +1,26 @@
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="..\..\dir.props" />
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <AssemblyName>Mono.Build.Tasks</AssemblyName>
+        <DebugType>full</DebugType>
+    </PropertyGroup>
+
+   <ItemGroup>
+        <Compile Include="FilterDeniedAssemblies.cs" />
+
+        <Reference Include="Microsoft.Build.Framework" />
+        <Reference Include="Microsoft.Build.Utilities.v4.0" />
+
+        <Reference Include="System.Reflection.Metadata">
+            <HintPath>$(CompilerToolsDir)\System.Reflection.Metadata.dll</HintPath>
+        </Reference>
+        <Reference Include="System.Collections.Immutable">
+            <HintPath>$(CompilerToolsDir)\System.Collections.Immutable.dll</HintPath>
+        </Reference>
+   </ItemGroup>
+
+    <Target Name="Test" />
+
+    <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/mono/tests/DeniedAssemblyTest/DeniedAssemblyTest.sln
+++ b/mono/tests/DeniedAssemblyTest/DeniedAssemblyTest.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeniedAssemblyTest", "DeniedAssemblyTest\DeniedAssemblyTest.csproj", "{C2771525-5BE3-4461-8D72-6B3B1CDF93F5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C2771525-5BE3-4461-8D72-6B3B1CDF93F5}.Debug|x86.ActiveCfg = Debug|x86
+		{C2771525-5BE3-4461-8D72-6B3B1CDF93F5}.Debug|x86.Build.0 = Debug|x86
+		{C2771525-5BE3-4461-8D72-6B3B1CDF93F5}.Release|x86.ActiveCfg = Release|x86
+		{C2771525-5BE3-4461-8D72-6B3B1CDF93F5}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+EndGlobal

--- a/mono/tests/DeniedAssemblyTest/DeniedAssemblyTest/DeniedAssemblyTest.csproj
+++ b/mono/tests/DeniedAssemblyTest/DeniedAssemblyTest/DeniedAssemblyTest.csproj
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProjectGuid>{C2771525-5BE3-4461-8D72-6B3B1CDF93F5}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>DeniedAssemblyTest</RootNamespace>
+    <AssemblyName>DeniedAssemblyTest</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ExternalConsole>true</ExternalConsole>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="mscorlib" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Globalization.Extensions">
+      <HintPath>..\packages\System.Globalization.Extensions.4.3.0\lib\net46\System.Globalization.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Primitives">
+      <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.DiagnosticSource">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http">
+      <HintPath>..\packages\System.Net.Http.4.3.2\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Overlapped">
+      <HintPath>..\packages\System.Threading.Overlapped.4.3.0\lib\net46\System.Threading.Overlapped.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.DispatchProxy">
+      <HintPath>..\packages\System.Reflection.DispatchProxy.4.3.0\lib\netstandard1.3\System.Reflection.DispatchProxy.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+
+  <Target Name="Test" AfterTargets="Build">
+      <PropertyGroup>
+          <NumberOfFixedReferences>@(FilteredReferences->WithMetadataValue('FixedDeniedAssemblyPath', 'true')->Count())</NumberOfFixedReferences>
+          <NumberOfCannotFixReferences>@(FilteredReferences->WithMetadataValue('FixedDeniedAssemblyPath', 'false')->Count())</NumberOfCannotFixReferences>
+      </PropertyGroup>
+
+      <Error Text="%24(FilterDeniedAssemblies) is false, so references won't be filtered." Condition="'$(FilterDeniedAssemblies)' != 'true'" />
+
+      <Error Text="Expected 3 fixed up references but got $(NumberOfFixedReferences)" Condition="$(NumberOfFixedReferences) != 3" />
+      <Error Text="Expected 4 references that could not be fixed but got $(NumberOfCannotFixReferences)" Condition="$(NumberOfCannotFixReferences) != 4" />
+  </Target>
+</Project>

--- a/mono/tests/DeniedAssemblyTest/DeniedAssemblyTest/Program.cs
+++ b/mono/tests/DeniedAssemblyTest/DeniedAssemblyTest/Program.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+
+namespace DeniedAssemblyTest
+{
+    class MainClass
+    {
+        public static void Main(string[] args)
+        {
+            System.StringNormalizationExtensions.IsNormalized("hello");
+
+            var os = System.Runtime.InteropServices.OSPlatform.OSX;
+
+            var client = new System.Net.Http.HttpClient();
+
+            // system.threading.overlapped
+            var over = new System.Threading.PreAllocatedOverlapped(null, null, null);
+
+            // codepages
+            var provider = System.Text.CodePagesEncodingProvider.Instance;
+
+            // compression
+            var mode = System.IO.Compression.ZipArchiveMode.Create;
+            Console.WriteLine(mode);
+        }
+    }
+
+    abstract class DeriveFromDispatchProxy : System.Reflection.DispatchProxy
+    {}
+}

--- a/mono/tests/DeniedAssemblyTest/DeniedAssemblyTest/Properties/AssemblyInfo.cs
+++ b/mono/tests/DeniedAssemblyTest/DeniedAssemblyTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("DeniedAssemblyTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/mono/tests/DeniedAssemblyTest/DeniedAssemblyTest/packages.config
+++ b/mono/tests/DeniedAssemblyTest/DeniedAssemblyTest/packages.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net461" />
+  <package id="System.Globalization.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.2" targetFramework="net461" />
+  <package id="System.Reflection.DispatchProxy" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Overlapped" version="4.3.0" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
Mono denies loading certain "bad" assemblies because they include an
implementation that doesn't work under mono. Instead, mono provides it's
own implementations of the same which are safe to load.

These are specific versions from specific nugets. Mono installs a list
of these in $(MSBuildExtensionsPath)/deniedAssembliesList.txt .

If these bad assemblies get bundled with an app and the runtime tries to
load them, then they will get denied. If this is running from a full
mono installation, then the runtime continues looking for the assembly
in other locations.

But if this is a case, like a Mac app bundle (with Xamarin.Mac), which
uses it's own bundled mono+assemblies, then the runtime won't be able to
fallback to anything else. So, we want to ensure that we bundle the
"good" assemblies instead.

This is not an issue for XA/XI as they have their own
TargetFrameworkMoniker and so the nuget has `_._` for them. IOW, msbuild
uses the framework assemblies there.

Solution:

- We tried an approach of: filtering out such references
  (`@(Reference)`) before the `ResolveAssemblyReference` task. All the
  facades are passed to the compiler as references, so the correct
  assemblies will get pulled in accordingly.

  But the problem with this was that if after removing these, we ended
  up with no facade references, then `ResolveAssemblyReference` returns
  `DependsOnSystemRuntime=false`, which causes the facade assemblies to
  not be implicitly passed to the compiler!

- Instead, now we get the list of target framework directories and
  facade directories and look for the "good" assemblies in there. If we
  can find the assembly, then we update the reference (ItemSpec or HintPath) to
  the new path.
  Else, we warn the user and don't touch the reference!

For this, we add a `FilterDeniedAssemblies` tasks in a new
`Mono.Build.Tasks.dll`.

Note: the list is part of this commit for now. Before the merge, this
will be generated+installed from mono instead.