### PR TITLE
[mono] Disable `SGen` task, workaround for bxc#55697

### DIFF
--- a/mono/ExtensionsPath-ToolsVersion/Microsoft.Common.targets/ImportBefore/Microsoft.Common.Mono.Before.targets
+++ b/mono/ExtensionsPath-ToolsVersion/Microsoft.Common.targets/ImportBefore/Microsoft.Common.Mono.Before.targets
@@ -21,6 +21,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <!-- Mono's resgen doesn't support all the command line args, like /r:
              So, don't use the tool -->
 	    <ExecuteAsTool Condition="'$(ExecuteAsTool)' == '' and '$(MSBuildRuntimeType)' == 'Mono'">false</ExecuteAsTool>
+
+        <!-- Disable generation of serialization assemblies for now. workaround for bxc #55697 -->
+        <GenerateSerializationAssemblies Condition="'$(GenerateSerializationAssemblies)' == ''">Off</GenerateSerializationAssemblies>
     </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
For a XI project (for example), `sgen.exe` fails to correct resolve and load the XI
references from the main assembly and fails with:
```
GenerateSerializationAssemblies:
  /Library/Frameworks/Mono.framework/Versions/4.8.0/lib/mono/4.5/sgen.exe /assembly:/Users/ankit/Projects/DM_XI_WebRef/DM_XI_WebRef/obj/iPhoneSimulator/Release/DM_XI_WebRef.exe /proxytypes /reference:/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/mscorlib.dll /reference:/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/System.Core.dll /reference:/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/System.dll /reference:/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/System.Web.Services.dll /reference:/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/System.Xml.dll /reference:/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS/Xamarin.iOS.dll

  Unhandled Exception:
  System.Reflection.ReflectionTypeLoadException: The classes in the module cannot be loaded.
    at (wrapper managed-to-native) System.Reflection.Assembly:GetTypes (System.Reflection.Assembly,bool)
    at System.Reflection.Assembly.GetTypes () [0x00000] in <f712f98eb8e445c8918edaf595bbe465>:0
    at Driver.Run (System.String[] args) [0x00114] in <7704802842fe4a00bb019bc9daef1009>:0
    at Driver.Main (System.String[] args) [0x00006] in <7704802842fe4a00bb019bc9daef1009>:0
  [ERROR] FATAL UNHANDLED EXCEPTION: System.Reflection.ReflectionTypeLoadException: The classes in the module cannot be loaded.
    at (wrapper managed-to-native) System.Reflection.Assembly:GetTypes (System.Reflection.Assembly,bool)
    at System.Reflection.Assembly.GetTypes () [0x00000] in <f712f98eb8e445c8918edaf595bbe465>:0
    at Driver.Run (System.String[] args) [0x00114] in <7704802842fe4a00bb019bc9daef1009>:0
    at Driver.Main (System.String[] args) [0x00006] in <7704802842fe4a00bb019bc9daef1009>:0
```

The same project builds with xbuild as it never used `sgen`. And it
fails with msbuild because it uses sgen by default on non-Debug
configurations.

As a workaround, disable use of sgen completely.