### PR TITLE
[mono] Disables tests that are breaking xunit/osx

### DIFF
--- a/src/Tasks.UnitTests/GenerateResourceOutOfProc_Tests.cs
+++ b/src/Tasks.UnitTests/GenerateResourceOutOfProc_Tests.cs
@@ -2325,6 +2325,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.OutOfProc
         }
 
         [Fact]
+        [Trait("Category", "mono-osx-failing")]
         public void Regress25163_OutputResourcesContainsInvalidPathCharacters()
         {
             string resourcesFile = null;

--- a/src/Tasks.UnitTests/GenerateResource_Tests.cs
+++ b/src/Tasks.UnitTests/GenerateResource_Tests.cs
@@ -2330,6 +2330,7 @@ namespace Microsoft.Build.UnitTests.GenerateResource_Tests.InProc
 #else
         [Fact(Skip = "Does not support strongly typed resources on netcore")]
 #endif
+        [Trait("Category", "mono-osx-failing")]
         public void BadStronglyTypedFilename()
         {
             string txtFile = null;


### PR DESCRIPTION
Some GenerateResource tests use `\0` as invalid file names on !windows.
And xunit tries to write the output of that build to xml (CDATA) without
filtering the NUL, and we get a ArgumentException.

Upstream worked around[1] this by disabling the tests. We are doing the
same here, till we have a build of xunit that fixes the issue.

Manifests on CI:
This issue causes the test build to fail as the exception is thrown
after all the tests have run and xunit is trying to write the xml
results file! So, wrench ends up with "failed" tests even though none of
the tests actually failed!

--
1. commit: 4603358e77ff5ebe46c33bbe21e7ae7d7ea7c642