### PR TITLE
[mono] cibuild: use existing packages/msbuild.zip

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -38,8 +38,11 @@ downloadMSBuildForMono()
     then
         mkdir -p "$PACKAGES_DIR" # Create packages dir if it doesn't exist.
 
-        echo "** Downloading MSBUILD from $MSBUILD_DOWNLOAD_URL"
-        curl -sL -o "$MSBUILD_ZIP" "$MSBUILD_DOWNLOAD_URL"
+       if [ ! -e "$MSBUILD_ZIP" ]
+        then
+            echo "** Downloading MSBUILD from $MSBUILD_DOWNLOAD_URL"
+            curl -sL -o "$MSBUILD_ZIP" "$MSBUILD_DOWNLOAD_URL"
+        fi
 
         unzip -q "$MSBUILD_ZIP" -d "$PACKAGES_DIR"
         find "$PACKAGES_DIR/msbuild" -name "*.exe" -exec chmod "+x" '{}' ';'

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -89,17 +89,20 @@ fi
 if [ ! -e $__INIT_TOOLS_DONE_MARKER ]; then
     if [ -e $__TOOLRUNTIME_DIR ]; then rm -rf -- $__TOOLRUNTIME_DIR; fi
     echo "Running: $__scriptpath/init-tools.sh" > $__init_tools_log
-    if [ ! -e $__DOTNET_PATH ]; then
+    
+    if [ ! -e $__DOTNET_PATH/dotnet ]; then
         echo "Installing dotnet cli..."
-        __DOTNET_LOCATION="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/${__DOTNET_TOOLS_VERSION}/${__DOTNET_PKG}.${__DOTNET_TOOLS_VERSION}.tar.gz"
-        # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
-        echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> $__init_tools_log
-        which curl > /dev/null 2> /dev/null
-        if [ $? -ne 0 ]; then
-            mkdir -p "$__DOTNET_PATH"
-            wget -q -O $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
-        else
-            curl --retry 10 -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
+        if [ ! -e $__DOTNET_PATH/dotnet.tar ]; then
+            __DOTNET_LOCATION="https://dotnetcli.blob.core.windows.net/dotnet/Sdk/${__DOTNET_TOOLS_VERSION}/${__DOTNET_PKG}.${__DOTNET_TOOLS_VERSION}.tar.gz"
+            # curl has HTTPS CA trust-issues less often than wget, so lets try that first.
+            echo "Installing '${__DOTNET_LOCATION}' to '$__DOTNET_PATH/dotnet.tar'" >> $__init_tools_log
+            which curl > /dev/null 2> /dev/null
+            if [ $? -ne 0 ]; then
+                mkdir -p "$__DOTNET_PATH"
+                wget -q -O $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
+            else
+                curl --retry 10 -sSL --create-dirs -o $__DOTNET_PATH/dotnet.tar ${__DOTNET_LOCATION}
+            fi
         fi
         cd $__DOTNET_PATH
         tar -xf $__DOTNET_PATH/dotnet.tar


### PR DESCRIPTION
This allows Flatpak (sandboxed build with no network) to run cibuild.sh after putting the msbuild.zip binary in place ahead of time.