### PR TITLE
[mono] Cache the IsOSX check (#2863)

### DIFF
--- a/src/Shared/NativeMethodsShared.cs
+++ b/src/Shared/NativeMethodsShared.cs
@@ -546,14 +546,25 @@ namespace Microsoft.Build.Shared
             get { return RuntimeInformation.IsOSPlatform(OSPlatform.Windows); }
 #endif
         }
-
+        
+#if MONO
+        private static bool? _isOSX;
+#endif
         /// <summary>
         /// Gets a flag indicating if we are running under Mac OSX
         /// </summary>
         internal static bool IsOSX
         {
 #if MONO
-            get { return File.Exists("/usr/lib/libc.dylib"); }
+            get
+            {
+                if (!_isOSX.HasValue)
+                {
+                    _isOSX = File.Exists("/usr/lib/libc.dylib");
+                }
+
+                return _isOSX.Value;
+            }
 #elif CLR2COMPATIBILITY
             get { return false; }
 #else


### PR DESCRIPTION
This ensures we won't hit the filesystem a few million times
during project evaluation.

Fixes mono/mono#6530.

(cherry picked from commit a80ce1f1ec82586a946e0a3edcfb0fa760732133)