### PR TITLE
[mono] Filter windows-specific net4x assemblies

### DIFF
--- a/mono/ExtensionsPath-ToolsVersion/Microsoft.Common.targets/ImportAfter/Microsoft.Common.Mono.After.targets
+++ b/mono/ExtensionsPath-ToolsVersion/Microsoft.Common.targets/ImportAfter/Microsoft.Common.Mono.After.targets
@@ -13,14 +13,26 @@ Copyright (C) Microsoft Corporation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <UsingTask TaskName="Mono.Build.Tasks.FilterDeniedAssemblies" AssemblyFile="$(MSBuildExtensionsPath)\Mono.Build.Tasks.dll" />
 
-    <PropertyGroup>
-        <FilterDeniedAssemblies Condition="$(FilterDeniedAssemblies) == ''">false</FilterDeniedAssemblies>
-    </PropertyGroup>
+    <!--
+         This closely depends on Microsoft/Microsoft.NET.Build.Extensions/Microsoft.NET.Build.Extensions.NETFramework.targets .
+         Specifically, on the `ImplicitlyExpandNETStandardFacades` target which sets
 
+            $(ImplicitlyExpandNETStandardFacades),
+            $(DependsOnNETStandard) and
+            $(NETStandardInbox)
+
+        and is enabled only for '$(TargetFrameworkIdentifier)' == '.NETFramework'.
+
+        Default:
+        - Run this only for .net framework projects 4.6.1 - 4.7, which have any references depending on netstandard
+         -->
     <Target
         Name="FilterDeniedAssemblyReferences"
         BeforeTargets="ResolveAssemblyReferences"
-        Condition="'$(FilterDeniedAssemblies)' == 'true'">
+        Condition="'$(FilterDeniedAssemblies)' == 'true'
+                        or ('$(EnableFilteringDeniedAssembliesForNet46xProjects)' != 'false' and '$(FilterDeniedAssemblies)' == ''
+                            and '$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(ImplicitlyExpandNETStandardFacades)' == 'true'
+                            and '$(DependsOnNETStandard)' == 'true'  AND '$(NETStandardInbox)' != 'true' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '4.7.1')">
 
         <FilterDeniedAssemblies References="@(Reference)" SearchPaths="$(TargetFrameworkDirectory);$(DesignTimeFacadeDirectories)">
             <Output TaskParameter="DeniedReferencesThatCouldNotBeFixed" ItemName="DeniedReferencesThatCouldNotBeFixed" />


### PR DESCRIPTION
We bundle net4x assemblies from Microsoft.NET.Build.Extensions, some of
which are windows-specific and not compatible with mono/!windows. We
have an existing mechanism `FilterDeniedAssemblies` to filter out such
assemblies before reference resolution.

This was enabled only by Xamarin.Mac . But here we enable it for any
.net framework project (4.6.1 - 4.7) which might directly or indirectly
reference netstandard, since in this case the bundled net4x assemblies
get used.

The assemblies get local-copied, but at runtime these are denied by
mono.

Fixes: #60315