### PR TITLE
Traits: This caches values of various environment variables which act as

### DIFF
--- a/src/Shared/Traits.cs
+++ b/src/Shared/Traits.cs
@@ -18,12 +18,10 @@ namespace Microsoft.Build.Utilities
         {
             get
             {
-#if DEBUG
                 if (BuildEnvironmentHelper.Instance.RunningTests && Environment.GetEnvironmentVariable("MSBUILDRELOADTRAITSONEACHACCESS") == "1")
                 {
                     return new Traits();
                 }
-#endif
                 return _instance;
             }
         }


### PR DESCRIPTION
.. switches to control features like logging imports. For use with
tests, this caching can be disabled but that is enabled only for DEBUG
builds. Which means that any tests trying to toggle and test those
environment variable dependent features will work only for debug builds.

So, we remove that restriction. And because the condition first checks if we are
running tests and only then looks at

    Environment.GetEnvironmentVariable("MSBUILDRELOADTRAITSONEACHACCESS")

.. it shouldn't affect performance much (untested!).