### PR TITLE
Actually require Bash in a Bash-heavy script

### DIFF
--- a/msbuild
+++ b/msbuild
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ABSOLUTE_PATH=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)/`basename "${BASH_SOURCE[0]}"`
 MSBUILD_SRC_DIR=`dirname $ABSOLUTE_PATH`
 #mono $MONO_OPTIONS $MSBUILD_SRC_DIR/bin/Debug-MONO/OSX_Deployment/MSBuild.exe /p:CscToolExe=mcs.exe /p:UseSharedCompilation=false /p:DebugFileExt=.mdb $*


### PR DESCRIPTION
Debian & Ubuntu have `/bin/sh` as `dash`, a fast POSIX-compliant shell.

Dash doesn't understand `${BASH_SOURCE[0]}`

As-is, building msbuild from 2018-04 branch fails, as the downloaded msbuild release doesn't work with sh->dash

```
** Downloading MSBUILD from https://github.com/mono/msbuild/releases/download/v0.05/mono_msbuild_port2-394a6b5e.zip
============= MSBuild command =============
/tmp/msbuild-15.7/build/../artifacts/mono-msbuild/msbuild "/tmp/msbuild-15.7/build/Toolset.proj" /t:restore /m /clp:Summary /warnaserror /v:minimal /bl:"/tmp/msbuild-15.7/build/../artifacts/Release-MONO/log/Toolset.binlog"
===========================================
/tmp/msbuild-15.7/build/../artifacts/mono-msbuild/msbuild: 1: /tmp/msbuild-15.7/build/../artifacts/mono-msbuild/msbuild: Bad substitution
/tmp/msbuild-15.7/build/../artifacts/mono-msbuild/msbuild: 1: /tmp/msbuild-15.7/build/../artifacts/mono-msbuild/msbuild: Bad substitution
Cannot open assembly '/home/MSBuild.dll': No such file or directory.
Failed to run MSBuild
```