### PR TITLE
[mono] Fix VSMac build with .netcore 2.1 installed

### DIFF
--- a/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
+++ b/src/MSBuild.Bootstrap/MSBuild.Bootstrap.csproj
@@ -34,9 +34,6 @@
 
     <!-- Use the NuGet.targets that we bundle, since that is what we will install so we should be testing against that -->
     <Content Include="$(RepoRoot)nuget-support\tasks-targets\*" CopyToOutputDirectory="PreserveNewest" />
-
-    <!-- Include DependencyModel libraries. -->
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MonoBuild)' != 'true'">


### PR DESCRIPTION
For the mono build we have a dependency on
`Microsoft.Extensions.DependencyModel`, and so we get the assembly in
the binDir.

When building a netstandard project, the MSBuild sdk resolver resolves
to the installed dotnet (2.1 RC in this case).
`Microsoft.NET.Build.Tasks` is loaded from there but it's dependency is
available in msbuild's(entry assembly) binDir itself, so it gets loaded
from there.  And because the one from dotnet has a new
class `Microsoft.Extensions.DependencyModel.RuntimeFile`,
this fails at runtime with:

`System.TypeLoadException: Could not resolve type with token 01000030 from typeref (expected class 'Microsoft.Extensions.DependencyModel.RuntimeFile' in assembly 'Microsoft.Extensions.DependencyModel, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60')`

This assembly isn't required for mono msbuild because it is meant for
reading `.deps` files. And this does not affect building netcoreapps,
because in that case the sdk resolver uses the installed `dotnet`. And
if it isn't installed, then we just use our bundled SDK which already
has this assembly.

Fixes bug: https://github.com/mono/mono/issues/8715

(cherry picked from commit bef41bc937c7ee9d84bd14a44cbb8ea971a90649)