### PR TITLE
[mono] Fix building with mcs.exe

### DIFF
--- a/src/Tasks/Microsoft.CSharp.Mono.targets
+++ b/src/Tasks/Microsoft.CSharp.Mono.targets
@@ -43,6 +43,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <_ConfigurationNameTmp Condition="'$(ConfigurationName)' == ''">$(Configuration)</_ConfigurationNameTmp>
 
         <UseSharedCompilation Condition="'$(UseSharedCompilation)' == ''">false</UseSharedCompilation>
+        <CscToolPath Condition="'$(CscToolPath)' == '' and '$(CscToolExe)' == 'mcs.exe'">$(MSBuildFrameworkToolsPath)</CscToolPath>
         <DebugType Condition="'$(OS)' != 'Windows_NT' And ('$(DebugSymbols)'=='True' or ('$(DebugSymbols)'=='' And '$(_ConfigurationNameTmp)'=='Debug'))">portable</DebugType>
     </PropertyGroup>
 


### PR DESCRIPTION
Earlier we were explicitly setting `CscToolPath` to
`$(MSBuildFrameworkToolsPath)` as we had mcs.exe/csc.exe installed there. (157a0f4d1a7aadd4e561e3ca8c784cbc2529926f)

Then we added symlinks in `msbuild_bin_dir/Roslyn/`, which is the
default location where roslyn tasks look for the compiler, so we removed
the above change (4389e23b1feec4864d66fb36accb1aa76e853261).

But this breaks the scenario where the user only overrides
`CscToolExe=mcs.exe` and doesn't set `CscToolPath`. To keep that
working, we now set `CscToolPath=$(MSBuildFrameworkToolsPath)`.

Note: We want to avoid setting the `CscToolPath` for csc case, because
the Csc task depends on this property unset to allow use of the shared
compiler, which we want to eventually use!

Fixes https://github.com/mono/mono/issues/8893