### PR TITLE
Revert "[mono] Roslyn does not support signing assemblies on non-wind…

### DIFF
--- a/src/Tasks/Microsoft.CSharp.Mono.targets
+++ b/src/Tasks/Microsoft.CSharp.Mono.targets
@@ -46,11 +46,4 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <CscToolPath Condition="'$(CscToolPath)' == '' and '$(CscToolExe)' == 'mcs.exe'">$(MSBuildFrameworkToolsPath)</CscToolPath>
         <DebugType Condition="'$(OS)' != 'Windows_NT' And ('$(DebugSymbols)'=='True' or ('$(DebugSymbols)'=='' And '$(_ConfigurationNameTmp)'=='Debug'))">portable</DebugType>
     </PropertyGroup>
-
-    <Target Name="_RoslynPublicSignHack" BeforeTargets="CoreCompile">
-        <PropertyGroup>
-            <_UseRoslynPublicSignHack Condition="'$(_UseRoslynPublicSignHack)' == ''">true</_UseRoslynPublicSignHack>
-            <PublicSign Condition="'$(OS)' != 'Windows_NT' and ('$(CscToolExe)' == '' or '$(CscToolExe)' == 'csc.exe' or '$(CscToolExe)' == 'csc') and '$(KeyOriginatorFile)' != '' and '$(DelaySign)' != 'true' and '$(_UseRoslynPublicSignHack)' == 'true'">true</PublicSign>
-        </PropertyGroup>
-    </Target>
 </Project>


### PR DESCRIPTION
…ows"

This reverts commit 665f843ac664eb2b4541242c1d6e364a9a838ac8.

Roslyn supports signing on !windows now, with 2.7+ . And this is bundled
with mono/2018-04 which uses roslyn 2.7 .

Fixes https://github.com/mono/mono/issues/8495 .