### PR TITLE
[mono] Fix mono bootstrap download url

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -464,10 +464,6 @@ LogDir="$ArtifactsConfigurationDir/log"
 VersionsProps="$ScriptRoot/Versions.props"
 RepoToolsetDir="$ArtifactsDir/toolset"
 
-MONO_MSBUILD_DIR="$ArtifactsDir/mono-msbuild"
-MSBUILD_DOWNLOAD_URL="https://github.com/mono/msbuild/releases/download/0.06/mono_msbuild_xplat-master-3c930fa8.zip"
-MSBUILD_ZIP="$ArtifactsDir/msbuild.zip"
-
 #https://github.com/dotnet/source-build
 if $dotnetBuildFromSource
 then
@@ -478,7 +474,7 @@ fi
 
 msbuildToUse="msbuild"
 MONO_MSBUILD_DIR="$ArtifactsDir/mono-msbuild"
-MSBUILD_DOWNLOAD_URL="https://github.com/mono/msbuild/releases/download/v0.05/mono_msbuild_port2-394a6b5e.zip"
+MSBUILD_DOWNLOAD_URL="https://github.com/mono/msbuild/releases/download/0.06/mono_msbuild_xplat-master-3c930fa8.zip"
 MSBUILD_ZIP="$ArtifactsDir/msbuild.zip"
 
 log=false


### PR DESCRIPTION
.. which was getting overwritten by an older one, due to a bad merge!

The older one is missing the commit
a5a9fd56fce932bd2987be450ed34ca53e6040e6, required for linux builds.

Thanks to @directhex for catching this.