### PR TITLE
[mono] Fix regresion for XA (issue #1845)

### DIFF
--- a/src/Tasks/GetReferenceAssemblyPaths.cs
+++ b/src/Tasks/GetReferenceAssemblyPaths.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Build.Tasks
         private static bool? s_net35SP1SentinelAssemblyFound;
 #endif
 
+        private static bool FallbackPathHackOnOSXEnabled = NativeMethodsShared.IsOSX && NativeMethodsShared.IsMono && String.IsNullOrEmpty(Environment.GetEnvironmentVariable("DISABLE_FALLBACK_PATHS_HACK_IN_GRAP_OSX"));
+
         /// <summary>
         /// Hold the reference assembly paths based on the passed in targetframeworkmoniker.
         /// </summary>
@@ -293,12 +295,17 @@ namespace Microsoft.Build.Tasks
         /// FIXME: do we really need the new arg? or should we just use the property?
         private IList<String> GetPaths(string rootPath, string targetFrameworkFallbackSearchPaths, FrameworkNameVersioning frameworkmoniker)
         {
+            string fallbackPathsToUse = (FallbackPathHackOnOSXEnabled && String.IsNullOrEmpty(targetFrameworkFallbackSearchPaths))
+                                            ? fallbackPathsToUse = "/Library/Frameworks/Mono.framework/External/xbuild-frameworks"
+                                            : targetFrameworkFallbackSearchPaths;
+
+
             IList<String> pathsToReturn = ToolLocationHelper.GetPathToReferenceAssemblies(
                                                 frameworkmoniker.Identifier,
                                                 frameworkmoniker.Version.ToString(),
                                                 frameworkmoniker.Profile,
                                                 rootPath,
-                                                targetFrameworkFallbackSearchPaths);
+                                                fallbackPathsToUse);
 
             if (!SuppressNotFoundError)
             {


### PR DESCRIPTION
TargetFrameworks on osx have a default fallback search path:

    `/Library/Frameworks/Mono.framework/External/xbuild-frameworks`

This was earlier implemented in mono/msbuild via the app.config, but
then was changed to be specified via the property
`$(TargetFrameworkFallbackSearchPaths)`. And passed to
`GetReferenceAssemblyPaths` task via a new parameter
`TargetFrameworkFallbackSearchPaths`.

This also means that if any user of `GetReferenceAssemblyPaths` does not
use this new parameter, then on osx, msbuild won't be using any fallback
search path. In msbuild's targets files, we pass the new property as
argument for the new GRAP task parameter.

Accordingly, any non-msbuild users(targets) will need to update their
use of GRAP task to get the search path. But this would break any
existing/older users which are not using the new parameter and suddenly
find that projects won't build because of the missing search path.
Existing versions of Xamarin.Android are one example.

To ensure that they can continue working, we internally use the fallback
path if nothing is passed to the task. This can be disabled by setting
`DISABLE_FALLBACK_PATHS_HACK_IN_GRAP_OSX` env var.

Fixes https://github.com/xamarin/xamarin-android/issues/1845