### PR TITLE
Revert "Allow overriding fallback paths for MSBuildExtensionsPath via…

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskRegistry_Tests.cs
@@ -1897,8 +1897,8 @@ namespace Microsoft.Build.UnitTests.BackEnd
                     "dotv",
                     new Dictionary<string, ProjectImportPathMatch>
                     {
-                        {"a", new ProjectImportPathMatch("a", "b;c")},
-                        {"d", new ProjectImportPathMatch("d", "e;f")}
+                        {"a", new ProjectImportPathMatch("a", new List<string> {"b", "c"})},
+                        {"d", new ProjectImportPathMatch("d", new List<string> {"e", "f"})}
                     }
                 );
 

--- a/src/Build.UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
+++ b/src/Build.UnitTests/Definition/ToolsetConfigurationReader_Tests.cs
@@ -526,7 +526,7 @@ namespace Microsoft.Build.UnitTests.Definition
                             <property name=""MSBuildExtensionsPath64"" value=""c:\foo64;c:\bar64""/>
                          </searchPaths>
                          <searchPaths os=""osx"">
-                            <property name=""MSBuildExtensionsPath"" value=""/tmp/foo;$(FallbackPaths)""/>
+                            <property name=""MSBuildExtensionsPath"" value=""/tmp/foo""/>
                             <property name=""MSBuildExtensionsPath32"" value=""/tmp/foo32;/tmp/bar32""/>
                          </searchPaths>
                          <searchPaths os=""unix"">
@@ -557,7 +557,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
             Assert.Equal(allPaths.GetElement(1).OS, "osx");
             Assert.Equal(allPaths.GetElement(1).PropertyElements.Count, 2);
-            Assert.Equal(allPaths.GetElement(1).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"/tmp/foo;$(FallbackPaths)");
+            Assert.Equal(allPaths.GetElement(1).PropertyElements.GetElement("MSBuildExtensionsPath").Value, @"/tmp/foo");
             Assert.Equal(allPaths.GetElement(1).PropertyElements.GetElement("MSBuildExtensionsPath32").Value, @"/tmp/foo32;/tmp/bar32");
 
             Assert.Equal(allPaths.GetElement(2).OS, "unix");
@@ -578,7 +578,7 @@ namespace Microsoft.Build.UnitTests.Definition
             }
             else if (NativeMethodsShared.IsOSX)
             {
-                CheckPathsTable(pathsTable, "MSBuildExtensionsPath", new string[] {"/tmp/foo", "$(FallbackPaths)"});
+                CheckPathsTable(pathsTable, "MSBuildExtensionsPath", new string[] {"/tmp/foo"});
                 CheckPathsTable(pathsTable, "MSBuildExtensionsPath32", new string[] {"/tmp/foo32", "/tmp/bar32"});
             }
             else
@@ -591,16 +591,11 @@ namespace Microsoft.Build.UnitTests.Definition
         {
             Assert.True(pathsTable.ContainsKey(kind));
             var paths = pathsTable[kind];
+            Assert.Equal(paths.SearchPaths.Count, expectedPaths.Length);
 
-            // Property expansion would be done in the context of an
-            // actual project. So, without that, pathsTable would
-            // have the unexpanded strings.
-            var searchPaths = paths.GetExpandedSearchPaths(p => p);
-            Assert.Equal(searchPaths.Count, expectedPaths.Length);
-
-            for (int i = 0; i < searchPaths.Count; i ++)
+            for (int i = 0; i < paths.SearchPaths.Count; i ++)
             {
-                Assert.Equal(searchPaths[i], expectedPaths[i]);
+                Assert.Equal(paths.SearchPaths[i], expectedPaths[i]);
             }
         }
 

--- a/src/Build.UnitTests/Definition/Toolset_Tests.cs
+++ b/src/Build.UnitTests/Definition/Toolset_Tests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Build.UnitTests.Definition
             Toolset t = new Toolset("4.0", "c:\\bar", buildProperties, environmentProperties, globalProperties,
                 subToolsets, "c:\\foo", "4.0", new Dictionary<string, ProjectImportPathMatch>
                 {
-                    ["MSBuildExtensionsPath"] = new ProjectImportPathMatch("MSBuildExtensionsPath", @"c:\foo")
+                    ["MSBuildExtensionsPath"] = new ProjectImportPathMatch("MSBuildExtensionsPath", new List<string> {@"c:\foo"})
                 });
 
             ((INodePacketTranslatable)t).Translate(TranslationHelpers.GetWriteTranslator());
@@ -162,7 +162,7 @@ namespace Microsoft.Build.UnitTests.Definition
 
             Assert.NotNull(t2.ImportPropertySearchPathsTable);
             Assert.Equal(1, t2.ImportPropertySearchPathsTable.Count);
-            Assert.Equal(@"c:\foo", t2.ImportPropertySearchPathsTable["MSBuildExtensionsPath"].GetExpandedSearchPaths(p => p)[0]);
+            Assert.Equal(@"c:\foo", t2.ImportPropertySearchPathsTable["MSBuildExtensionsPath"].SearchPaths[0]);
         }
 
         [Fact]

--- a/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/ImportFromMSBuildExtensionsPath_Tests.cs
@@ -515,31 +515,16 @@ namespace Microsoft.Build.UnitTests.Evaluation
             }
         }
 
-        [Theory]
-        [InlineData(
-                "/a/b;$(FallbackPaths);/x/y",
-                @"<IndirectRefProperty>$(FallbackExpandDir1);/a/b</IndirectRefProperty>
-                <FallbackPaths>/xyz/tmp;$(IndirectRefProperty)</FallbackPaths>", null, false)]
-        // has fallback paths, but won't point to the valid one
-        [InlineData(
-                "/a/b;$(NonExistantProperty)",
-                "",
-                typeof (InvalidProjectFileException), true)]
-        // no fallback paths after expansion, so should ignore fallback-paths code path
-        [InlineData(
-                "$(NonExistantProperty)",
-                @"", typeof(InvalidProjectFileException), false)]
-        // no fallback paths after expansion, so should ignore fallback-paths code path
-        [InlineData(
-                "",
-                @"", typeof(InvalidProjectFileException), false)]
-        public void ExpandExtensionsPathFallback(string fallbackPathsInAppConfig, string propertiesInMainProject, Type expectedException, bool exceptionHasFallbacks)
+        // Fall-back path that has a property in it: $(FallbackExpandDir1)
+        [Fact]
+        public void ExpandExtensionsPathFallback()
         {
             string extnTargetsFileContentTemplate = @"
                 <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
                     <Target Name='FromExtn'>
                         <Message Text='Running FromExtn'/>
                     </Target>
+                    <Import Project='$(MSBuildExtensionsPath)\\foo\\extn.proj' Condition=""Exists('$(MSBuildExtensionsPath)\foo\extn.proj')"" />
                 </Project>";
 
             var configFileContents = @"
@@ -553,7 +538,7 @@ namespace Microsoft.Build.UnitTests.Evaluation
                        <property name=""MSBuildBinPath"" value="".""/>
                        <projectImportSearchPaths>
                          <searchPaths os=""" + NativeMethodsShared.GetOSNameForExtensionsPath() + @""">
-                           <property name=""MSBuildExtensionsPath"" value=""" + fallbackPathsInAppConfig + @""" />
+                           <property name=""MSBuildExtensionsPath"" value=""$(FallbackExpandDir1)"" />
                          </searchPaths>
                        </projectImportSearchPaths>
                       </toolset>
@@ -565,57 +550,24 @@ namespace Microsoft.Build.UnitTests.Evaluation
 
             try
             {
-                string mainTargetsFileContent = @"
-                    <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' >
-                        <PropertyGroup>
-                            {0}
-                        </PropertyGroup>
-
-                        <Target Name='Main' DependsOnTargets='FromExtn'>
-                            <Message Text='PropertyFromExtn1: $(PropertyFromExtn1)'/>
-                        </Target>
-
-                        <Import Project='$({1})\foo\extn.proj'/>
-                    </Project>";
-
-                mainTargetsFileContent = string.Format(mainTargetsFileContent, propertiesInMainProject, "MSBuildExtensionsPath");
-                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj", mainTargetsFileContent);
-
                 extnDir1 = GetNewExtensionsPathAndCreateFile("extensions1", Path.Combine("foo", "extn.proj"),
                     extnTargetsFileContentTemplate);
+
+                mainProjectPath = ObjectModelHelpers.CreateFileInTempProjectDirectory("main.proj",
+                    GetMainTargetFileContent());
 
                 ToolsetConfigurationReaderTestHelper.WriteConfigFile(configFileContents);
                 var reader = GetStandardConfigurationReader();
 
+                var projectCollection = new ProjectCollection(new Dictionary<string, string> {["FallbackExpandDir1"] = extnDir1});
+
+                projectCollection.ResetToolsetsForTests(reader);
                 var logger = new MockLogger();
-                try {
-                    var projectCollection = new ProjectCollection(new Dictionary<string, string> {["FallbackExpandDir1"] = extnDir1});
+                projectCollection.RegisterLogger(logger);
 
-                    projectCollection.ResetToolsetsForTests(reader);
-                    projectCollection.RegisterLogger(logger);
-
-                    var project = projectCollection.LoadProject(mainProjectPath);
-                    Assert.True(project.Build("Main"));
-                    logger.AssertLogContains("Running FromExtn");
-
-                    Assert.True(expectedException == null, $"Didn't get any exception. Expected: {expectedException}");
-                }
-                catch (Exception ex)
-                {
-                    if (expectedException == null)
-                        throw;
-
-                    Assert.Equal(ex.GetType(), expectedException);
-
-                    if (exceptionHasFallbacks)
-                    {
-                        logger.AssertLogContains("in the fallback search path");
-                    }
-                    else
-                    {
-                        logger.AssertLogDoesntContain("in the fallback search path");
-                    }
-                }
+                var project = projectCollection.LoadProject(mainProjectPath);
+                Assert.True(project.Build("Main"));
+                logger.AssertLogContains("Running FromExtn");
             }
             finally
             {

--- a/src/Build/Definition/ProjectImportPathMatch.cs
+++ b/src/Build/Definition/ProjectImportPathMatch.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Build.BackEnd;
 using Microsoft.Build.Shared;
 
@@ -15,30 +14,18 @@ namespace Microsoft.Build.Evaluation
     internal class ProjectImportPathMatch : INodePacketTranslatable
     {
         /// <summary>
-        /// Character used to separate search paths specified for MSBuildExtensionsPath* in
-        /// the config file
-        /// </summary>
-        private static char s_separatorForExtensionsPathSearchPaths = ';';
-
-        /// <summary>
         /// ProjectImportPathMatch instance representing no fall-back
         /// </summary>
-        public static readonly ProjectImportPathMatch None = new ProjectImportPathMatch(string.Empty, string.Empty);
+        public static readonly ProjectImportPathMatch None = new ProjectImportPathMatch(string.Empty, new List<string>());
 
-        internal ProjectImportPathMatch(string propertyName, string propertyValue)
+        internal ProjectImportPathMatch(string propertyName, List<string> searchPaths)
         {
             ErrorUtilities.VerifyThrowArgumentNull(propertyName, nameof(propertyName));
-            ErrorUtilities.VerifyThrowArgumentNull(propertyValue, nameof(propertyValue));
+            ErrorUtilities.VerifyThrowArgumentNull(searchPaths, nameof(searchPaths));
 
             PropertyName = propertyName;
-            PropertyValue = propertyValue;
+            SearchPaths = searchPaths;
             MsBuildPropertyFormat = $"$({PropertyName})";
-
-            // cache the result for @propertyValue="" case also
-            if (!ProjectImportPathMatch.HasPropertyReference(propertyValue) || string.IsNullOrEmpty(propertyValue))
-            {
-                SearchPathsWithNoExpansionRequired = ProjectImportPathMatch.SplitSearchPaths(propertyValue);
-            }
         }
 
         public ProjectImportPathMatch(INodePacketTranslator translator)
@@ -52,11 +39,6 @@ namespace Microsoft.Build.Evaluation
         public string PropertyName;
 
         /// <summary>
-        /// String representation of the property value
-        /// </summary>
-        public string PropertyValue;
-
-        /// <summary>
         /// Returns the corresponding property name - eg. "$(MSBuildExtensionsPath32)"
         /// </summary>
         public string MsBuildPropertyFormat;
@@ -64,43 +46,14 @@ namespace Microsoft.Build.Evaluation
         /// <summary>
         /// Enumeration of the search paths for the property.
         /// </summary>
-        private List<string> SearchPathsWithNoExpansionRequired;
+        public List<string> SearchPaths;
 
         public void Translate(INodePacketTranslator translator)
         {
             translator.Translate(ref PropertyName);
-            translator.Translate(ref PropertyValue);
             translator.Translate(ref MsBuildPropertyFormat);
-            translator.Translate(ref SearchPathsWithNoExpansionRequired);
+            translator.Translate(ref SearchPaths);
         }
-
-        /// <summary>
-        /// Gets the list of search paths with any property references expanded using @expandPropertyReferences
-        /// <param name="expandPropertyReferences">Func that expands properties in a string</param>
-        /// <returns>List of expanded search paths</returns>
-        /// </summary>
-        public IList<string> GetExpandedSearchPaths(Func<string, string> expandPropertyReferences)
-        {
-            ErrorUtilities.VerifyThrowArgumentNull(expandPropertyReferences, nameof(expandPropertyReferences));
-
-            /// If SearchPathsWithNoExpansionRequired is not-null, then it means that the PropertyValue
-            /// did not have any property reference and so we just return the list we prepared during
-            /// construction.
-            return SearchPathsWithNoExpansionRequired ?? ProjectImportPathMatch.SplitSearchPaths(expandPropertyReferences(PropertyValue));
-        }
-
-        /// <summary>
-        /// Splits @fullString on @s_separatorForExtensionsPathSearchPaths
-        /// </summary>
-        /// FIXME: handle ; in path on Unix
-        private static List<string> SplitSearchPaths(string fullString) => fullString
-                                                                        .Split(new[] {s_separatorForExtensionsPathSearchPaths}, StringSplitOptions.RemoveEmptyEntries)
-                                                                        .Distinct().ToList();
-
-        /// <summary>
-        /// Returns true if @value might have a property reference
-        /// </summary>
-        private static bool HasPropertyReference(string value) => value.Contains("$(");
 
         /// <summary>
         /// Factory for serialization.

--- a/src/Build/Definition/ToolsetConfigurationReader.cs
+++ b/src/Build/Definition/ToolsetConfigurationReader.cs
@@ -37,6 +37,12 @@ namespace Microsoft.Build.Evaluation
         private bool _configurationReadAttempted = false;
 
         /// <summary>
+        /// Character used to separate search paths specified for MSBuildExtensionsPath* in
+        /// the config file
+        /// </summary>
+        private char _separatorForExtensionsPathSearchPaths = ';';
+
+        /// <summary>
         /// Cached values of tools version -> project import search paths table
         /// </summary>
         private readonly Dictionary<string, Dictionary<string, ProjectImportPathMatch>> _projectImportSearchPathsCache;
@@ -229,7 +235,13 @@ namespace Microsoft.Build.Evaluation
                     continue;
                 }
 
-                pathsTable.Add(property.Name, new ProjectImportPathMatch(property.Name, property.Value));
+                //FIXME: handle ; in path on Unix
+                var paths = property.Value
+                    .Split(new[] {_separatorForExtensionsPathSearchPaths}, StringSplitOptions.RemoveEmptyEntries)
+                    .Distinct()
+                    .Where(path => !string.IsNullOrEmpty(path));
+
+                pathsTable.Add(property.Name, new ProjectImportPathMatch(property.Name, paths.ToList()));
             }
 
             return pathsTable;

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -100,9 +100,9 @@
           </searchPaths>
 
           <searchPaths os="osx">
-            <property name="MSBuildExtensionsPath" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/"/>
-            <property name="MSBuildExtensionsPath32" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/"/>
-            <property name="MSBuildExtensionsPath64" value="$(MSBuildExtensionsPathFallbackPathsOverride);/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            <property name="MSBuildExtensionsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            <property name="MSBuildExtensionsPath32" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
+            <property name="MSBuildExtensionsPath64" value="/Library/Frameworks/Mono.framework/External/xbuild/"/>
 
             <property name="VSToolsPath" value="/Library/Frameworks/Mono.framework/External/xbuild/Microsoft/VisualStudio/v$(VisualStudioVersion)" />
           </searchPaths>


### PR DESCRIPTION
… a property (#59)"

This reverts commit c4e70a612bbe5454e7ddc6189b9ea8dce01d17c8.

This was not accepted upstream.
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/682034