### PR TITLE
[mono] Add Microsoft.NET.Sdk.Razor missed in the last update

### DIFF
--- a/sdks/Microsoft.NET.Sdk.Razor/Sdk/Sdk.props
+++ b/sdks/Microsoft.NET.Sdk.Razor/Sdk/Sdk.props
@@ -1,0 +1,25 @@
+<!--
+***********************************************************************************************
+Sdk.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+  <PropertyGroup>
+    <!-- Determines if the Razor Sdk is responsible for importing Microsoft.NET.Sdk. Microsoft.NET.Sdk.Web may have previously imported this. -->
+    <_RazorSdkImportsMicrosoftNetSdk Condition="'$(UsingMicrosoftNETSdk)' != 'true'">true</_RazorSdkImportsMicrosoftNetSdk>
+  </PropertyGroup>
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" Condition="'$(_RazorSdkImportsMicrosoftNetSdk)' == 'true'" />
+
+  <PropertyGroup>
+    <RazorSdkCurrentVersionProps Condition="'$(RazorSdkCurrentVersionProps)' == ''">$(MSBuildThisFileDirectory)..\build\netstandard2.0\Sdk.Razor.CurrentVersion.props</RazorSdkCurrentVersionProps>
+  </PropertyGroup>
+
+  <Import Project="$(RazorSdkCurrentVersionProps)" />
+</Project>

--- a/sdks/Microsoft.NET.Sdk.Razor/Sdk/Sdk.targets
+++ b/sdks/Microsoft.NET.Sdk.Razor/Sdk/Sdk.targets
@@ -1,0 +1,23 @@
+<!--
+***********************************************************************************************
+Sdk.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" Condition="'$(_RazorSdkImportsMicrosoftNetSdk)' == 'true'" />
+
+  <PropertyGroup Condition="'$(RazorSdkCurrentVersionTargets)' == ''">
+    <RazorSdkCurrentVersionTargets Condition="'$(IsCrossTargetingBuild)' == 'true'">$(MSBuildThisFileDirectory)..\buildMultiTargeting\Sdk.Razor.CurrentVersion.MultiTargeting.targets</RazorSdkCurrentVersionTargets>
+    <RazorSdkCurrentVersionTargets Condition="'$(IsCrossTargetingBuild)' != 'true'">$(MSBuildThisFileDirectory)..\build\netstandard2.0\Sdk.Razor.CurrentVersion.targets</RazorSdkCurrentVersionTargets>
+  </PropertyGroup>
+
+  <Import Project="$(RazorSdkCurrentVersionTargets)" />
+
+</Project>

--- a/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
+++ b/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.Compilation.targets
@@ -1,0 +1,181 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.Razor.Compilation.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project ToolsVersion="14.0">
+  <!--
+  What follows in this file is based on:
+     https://github.com/dotnet/roslyn/blob/4d92b18aee99ba8b1b4770ce65133e9ca65a94fe/src/Compilers/Core/MSBuildTask/Microsoft.CSharp.Core.targets
+
+  We need to keep this basically up to date, as well as track the set of modifications we've made. Try to keep the formatting
+  similar to the original to reduce noise. In general try to only deviate from the CoreCompile target when we need to for
+  correctness.
+
+  We also want to avoid doubling up on things that don't make a ton of sense in the Razor views assembly, like
+  embedded files and resources, these are already present in the application's assembly.
+
+  Changes:
+    Name="RazorCoreCompile"
+
+    Replace @(Compile) with @(RazorCompile)
+    Replace @(_DebugSymbolsIntermediatePath) with @(_RazorDebugSymbolsIntermediatePath)
+    Replace @(IntermediateAssembly) with @(RazorIntermediateAssembly)
+    Replace @(ReferencePathWithRefAssemblies) with @(RazorReferencePath)
+    Remove @(_CoreCompileResourceInputs) with @(_RazorCoreCompileResourceInputs)
+
+    Set TargetType="$(OutputType)" to TargetType="Library" - Razor is always a .dll
+
+    Remove Returns="@(CscCommandLineArgs)"
+
+    Remove @(EmbeddedFiles)
+    Remove $(ApplicationIcon) $(Win32Resource) $(Win32Manifest)
+    Remove @(EmbeddedDocumentation) and @(EmbeddedFiles)
+    Remove @(CustomAdditionalCompileInputs) and @(CustomAdditionalCompileOutputs)
+    Remove @(DocFileItem)
+    Remove PdbFile="$(PdbFile)"
+    Remove OutputRefAssembly="@(IntermediateRefAssembly)"
+
+    Remove EmbedAllSources="$(EmbedAllSources)" - not supported by our supported version of MSBuild
+
+    Remove additional steps after calling CSC
+
+    Add our FileWrites after the call to CSC
+  -->
+ <Target Name="RazorCoreCompile"
+          Inputs="$(MSBuildAllProjects);
+                  @(RazorCompile);
+                  $(AssemblyOriginatorKeyFile);
+                  @(RazorReferencePath);
+                  @(CompiledLicenseFile);
+                  @(LinkResource);
+                  $(ResolvedCodeAnalysisRuleSet);
+                  @(AdditionalFiles);
+                  @(_RazorCoreCompileResourceInputs)"
+          Outputs="@(RazorIntermediateAssembly);
+                   @(_RazorDebugSymbolsIntermediatePath);
+                   $(NonExistentFile)"
+          Condition="'@(RazorCompile)'!=''">
+    <!-- These two compiler warnings are raised when a reference is bound to a different version
+             than specified in the assembly reference version number.  MSBuild raises the same warning in this case,
+             so the compiler warning would be redundant. -->
+    <PropertyGroup Condition="('$(TargetFrameworkVersion)' != 'v1.0') and ('$(TargetFrameworkVersion)' != 'v1.1')">
+      <NoWarn>$(NoWarn);1701;1702</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <!-- To match historical behavior, when inside VS11+ disable the warning from csc.exe indicating that no sources were passed in-->
+      <NoWarn Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(VisualStudioVersion)' != '' AND '$(VisualStudioVersion)' &gt; '10.0'">$(NoWarn);2008</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(TargetingClr2Framework)' == 'true'">
+      <ReferencePathWithRefAssemblies>
+        <EmbedInteropTypes />
+      </ReferencePathWithRefAssemblies>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <!-- If the user has specified AppConfigForCompiler, we'll use it. If they have not, but they set UseAppConfigForCompiler,
+                 then we'll use AppConfig -->
+      <AppConfigForCompiler Condition="'$(AppConfigForCompiler)' == '' AND '$(UseAppConfigForCompiler)' == 'true'">$(AppConfig)</AppConfigForCompiler>
+    </PropertyGroup>
+
+    <!-- Prefer32Bit was introduced in .NET 4.5. Set it to false if we are targeting 4.0 -->
+    <PropertyGroup Condition="('$(TargetFrameworkVersion)' == 'v4.0')">
+      <Prefer32Bit>false</Prefer32Bit>
+    </PropertyGroup>
+
+    <!-- TODO: Remove this ItemGroup once it has been moved to "_GenerateCompileInputs" target in Microsoft.Common.CurrentVersion.targets.
+         https://github.com/dotnet/roslyn/issues/12223 -->
+    <ItemGroup Condition="('$(AdditionalFileItemNames)' != '')">
+      <AdditionalFileItems Include="$(AdditionalFileItemNames)" />
+      <AdditionalFiles Include="@(%(AdditionalFileItems.Identity))" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(UseSharedCompilation)' == ''">
+      <UseSharedCompilation>true</UseSharedCompilation>
+    </PropertyGroup>
+
+    <Csc
+         AdditionalLibPaths="$(AdditionalLibPaths)"
+         AddModules="@(AddModules)"
+         AdditionalFiles="@(AdditionalFiles)"
+         AllowUnsafeBlocks="$(AllowUnsafeBlocks)"
+         Analyzers="@(Analyzer)"
+         ApplicationConfiguration="$(AppConfigForCompiler)"
+         BaseAddress="$(BaseAddress)"
+         CheckForOverflowUnderflow="$(CheckForOverflowUnderflow)"
+         ChecksumAlgorithm="$(ChecksumAlgorithm)"
+         CodeAnalysisRuleSet="$(ResolvedCodeAnalysisRuleSet)"
+         CodePage="$(CodePage)"
+         DebugType="$(DebugType)"
+         DefineConstants="$(DefineConstants)"
+         DelaySign="$(DelaySign)"
+         DisabledWarnings="$(NoWarn)"
+         EmitDebugInformation="$(DebugSymbols)"
+         EnvironmentVariables="$(CscEnvironment)"
+         ErrorEndLocation="$(ErrorEndLocation)"
+         ErrorLog="$(ErrorLog)"
+         ErrorReport="$(ErrorReport)"
+         Features="$(Features)"
+         FileAlignment="$(FileAlignment)"
+         GenerateFullPaths="$(GenerateFullPaths)"
+         HighEntropyVA="$(HighEntropyVA)"
+         Instrument="$(Instrument)"
+         KeyContainer="$(KeyContainerName)"
+         KeyFile="$(KeyOriginatorFile)"
+         LangVersion="$(LangVersion)"
+         LinkResources="@(LinkResource)"
+         MainEntryPoint="$(StartupObject)"
+         ModuleAssemblyName="$(ModuleAssemblyName)"
+         NoConfig="true"
+         NoLogo="$(NoLogo)"
+         NoStandardLib="$(NoCompilerStandardLib)"
+         NoWin32Manifest="$(NoWin32Manifest)"
+         Optimize="$(Optimize)"
+         Deterministic="$(Deterministic)"
+         PublicSign="$(PublicSign)"
+         OutputAssembly="@(RazorIntermediateAssembly)"
+         Platform="$(PlatformTarget)"
+         Prefer32Bit="$(Prefer32Bit)"
+         PreferredUILang="$(PreferredUILang)"
+         ProvideCommandLineArgs="$(ProvideCommandLineArgs)"
+         References="@(RazorReferencePath)"
+         ReportAnalyzer="$(ReportAnalyzer)"
+         Resources="@(_RazorCoreCompileResourceInputs);@(CompiledLicenseFile)"
+         ResponseFiles="$(CompilerResponseFile)"
+         RuntimeMetadataVersion="$(RuntimeMetadataVersion)"
+         SharedCompilationId="$(SharedCompilationId)"
+         SkipCompilerExecution="$(SkipCompilerExecution)"
+         Sources="@(RazorCompile)"
+         SubsystemVersion="$(SubsystemVersion)"
+         TargetType="Library"
+         ToolExe="$(CscToolExe)"
+         ToolPath="$(CscToolPath)"
+         TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
+         UseHostCompilerIfAvailable="$(UseHostCompilerIfAvailable)"
+         UseSharedCompilation="$(UseSharedCompilation)"
+         Utf8Output="$(Utf8Output)"
+         VsSessionGuid="$(VsSessionGuid)"
+         WarningLevel="$(WarningLevel)"
+         WarningsAsErrors="$(WarningsAsErrors)"
+         WarningsNotAsErrors="$(WarningsNotAsErrors)"
+         PathMap="$(PathMap)"
+         SourceLink="$(SourceLink)">
+      <Output TaskParameter="CommandLineArgs" ItemName="CscCommandLineArgs" />
+    </Csc>
+
+    <ItemGroup>
+      <FileWrites Include="@(_RazorIntermediateAssembly)" Condition="Exists('@(_RazorIntermediateAssembly)')" />
+      <FileWrites Include="@(_RazorDebugSymbolsIntermediatePath)" Condition="Exists('@(_RazorDebugSymbolsIntermediatePath)')" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.DesignTime.targets
+++ b/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.DesignTime.targets
@@ -1,0 +1,48 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.Razor.DesignTime.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project ToolsVersion="14.0">
+
+  <ItemGroup>
+    <!--
+      Defines the generic .NET Core 'Razor' capability.
+
+      Note that we don't define any capabilities here that depend on the version of the runtime/toolset
+      in use by the project. Those capabilities are defined by the relevant runtime packages so that
+      we use the lack of the capability to detect downlevel scenarios.
+    -->
+    <ProjectCapability Include="DotNetCoreRazor"/>
+  </ItemGroup>
+
+  <!--
+    WebSdk imports these capabilities for nesting in DotNetCoreWeb projects.
+    Conditinally import these capabilities if the project isn't targeting the WebSdk.
+   -->
+  <ItemGroup Condition="'$(UsingMicrosoftNETSdkWeb)'==''">
+    <ProjectCapability Include="SupportHierarchyContextSvc" />
+    <ProjectCapability Include="DynamicDependentFile" />
+    <ProjectCapability Include="DynamicFileNesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Rules\RazorConfiguration.xaml">
+      <Context>File</Context>
+    </PropertyPageSchema>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Rules\RazorExtension.xaml">
+      <Context>File</Context>
+    </PropertyPageSchema>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Rules\RazorGeneral.xaml">
+      <Context>Project</Context>
+    </PropertyPageSchema>
+  </ItemGroup>
+
+</Project>

--- a/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.GenerateAssemblyInfo.targets
+++ b/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.GenerateAssemblyInfo.targets
@@ -1,0 +1,185 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.Razor.GenerateAssemblyInfo.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+  <PropertyGroup>
+    <!-- Determines if the generated Razor assembly includes an auto-generated assembly info. -->
+    <GenerateRazorTargetAssemblyInfo Condition="'$(GenerateRazorTargetAssemblyInfo)'==''">true</GenerateRazorTargetAssemblyInfo>
+
+    <!-- Set to true, to automatically include some AssemblyAttributes inferred from the project metadata in the generated Razor assembly -->
+    <EnableDefaultRazorTargetAssemblyInfoAttributes Condition="'$(EnableDefaultRazorTargetAssemblyInfoAttributes)'==''">true</EnableDefaultRazorTargetAssemblyInfoAttributes>
+
+    <!-- AssemblyInfo that gets added to the generated Razor dll -->
+    <RazorTargetAssemblyInfo Condition="'$(RazorTargetAssemblyInfo)'==''">$(IntermediateOutputPath)$(MSBuildProjectName).RazorTargetAssemblyInfo.cs</RazorTargetAssemblyInfo>
+    <_RazorTargetAssemblyInfoInputsCacheFile>$(IntermediateOutputPath)$(MSBuildProjectName).RazorTargetAssemblyInfo.cache</_RazorTargetAssemblyInfoInputsCacheFile>
+
+    <!-- AssemblyInfo that gets added to the project being compiled -->
+    <_RazorAssemblyInfo>$(IntermediateOutputPath)$(MSBuildProjectName).RazorAssemblyInfo.cs</_RazorAssemblyInfo>
+    <_RazorAssemblyInfoInputsCacheFile>$(IntermediateOutputPath)$(MSBuildProjectName).RazorAssemblyInfo.cache</_RazorAssemblyInfoInputsCacheFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateRazorTargetAssemblyInfoDependsOn>
+      GetRazorTargetAssemblyAttributes;
+      _CreateRazorTargetAssemblyInfoInputsCacheFile;
+      CoreGenerateRazorTargetAssemblyInfo
+    </GenerateRazorTargetAssemblyInfoDependsOn>
+  </PropertyGroup>
+
+  <Target
+    Name="GenerateRazorTargetAssemblyInfo"
+    DependsOnTargets="$(GenerateRazorTargetAssemblyInfoDependsOn)">
+  </Target>
+
+  <Target
+    Name="CoreGenerateRazorTargetAssemblyInfo"
+    Inputs="$(_RazorTargetAssemblyInfoInputsCacheFile)"
+    Outputs="$(RazorTargetAssemblyInfo)"
+    Condition="'$(GenerateRazorTargetAssemblyInfo)'=='true' AND '@(RazorCompile)'!=''">
+
+    <ItemGroup Condition="'$(GenerateRazorTargetAssemblyInfo)'=='true'">
+      <!-- Ensure the generated assemblyinfo file is not already part of RazorCompile sources -->
+      <RazorCompile Remove="$(RazorTargetAssemblyInfo)" />
+      <RazorCompile Include="$(RazorTargetAssemblyInfo)" />
+    </ItemGroup>
+
+    <WriteCodeFragment AssemblyAttributes="@(RazorTargetAssemblyAttribute)" Language="C#" OutputFile="$(RazorTargetAssemblyInfo)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(RazorTargetAssemblyInfo)" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target
+    Name="GetRazorTargetAssemblyAttributes"
+    DependsOnTargets="GetAssemblyVersion"
+    Condition="'$(EnableDefaultRazorTargetAssemblyInfoAttributes)'=='true'">
+
+    <PropertyGroup>
+      <RazorAssemblyFileVersion Condition="'$(RazorAssemblyFileVersion)' == ''">$(FileVersion)</RazorAssemblyFileVersion>
+      <RazorAssemblyInformationalVersion Condition="'$(RazorAssemblyInformationalVersion)' == ''">$(InformationalVersion)</RazorAssemblyInformationalVersion>
+      <RazorAssemblyDescription Condition="'$(RazorAssemblyDescription)'==''">$(Description)</RazorAssemblyDescription>
+      <RazorAssemblyTitle Condition="'$(RazorAssemblyTitle)'==''">$(RazorTargetName)</RazorAssemblyTitle>
+      <RazorAssemblyVersion Condition="'$(RazorAssemblyVersion)' == ''">$(AssemblyVersion)</RazorAssemblyVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <RazorTargetAssemblyAttribute Include="System.Reflection.AssemblyCompanyAttribute" Condition="'$(Company)' != '' and '$(GenerateAssemblyCompanyAttribute)' == 'true'">
+        <_Parameter1>$(Company)</_Parameter1>
+      </RazorTargetAssemblyAttribute>
+      <RazorTargetAssemblyAttribute Include="System.Reflection.AssemblyConfigurationAttribute" Condition="'$(Configuration)' != '' and '$(GenerateAssemblyConfigurationAttribute)' == 'true'">
+        <_Parameter1>$(Configuration)</_Parameter1>
+      </RazorTargetAssemblyAttribute>
+      <RazorTargetAssemblyAttribute Include="System.Reflection.AssemblyCopyrightAttribute" Condition="'$(Copyright)' != '' and '$(GenerateAssemblyCopyrightAttribute)' == 'true'">
+        <_Parameter1>$(Copyright)</_Parameter1>
+      </RazorTargetAssemblyAttribute>
+      <RazorTargetAssemblyAttribute Include="System.Reflection.AssemblyProductAttribute" Condition="'$(Product)' != '' and '$(GenerateAssemblyProductAttribute)' == 'true'">
+        <_Parameter1>$(Product)</_Parameter1>
+      </RazorTargetAssemblyAttribute>
+      <RazorTargetAssemblyAttribute Include="System.Resources.NeutralResourcesLanguageAttribute" Condition="'$(NeutralLanguage)' != '' and '$(GenerateNeutralResourcesLanguageAttribute)' == 'true'">
+        <_Parameter1>$(NeutralLanguage)</_Parameter1>
+      </RazorTargetAssemblyAttribute>
+
+      <RazorTargetAssemblyAttribute Include="System.Reflection.AssemblyDescriptionAttribute" Condition="'$(RazorAssemblyDescription)' != '' and '$(GenerateAssemblyDescriptionAttribute)' == 'true'">
+        <_Parameter1>$(RazorAssemblyDescription)</_Parameter1>
+      </RazorTargetAssemblyAttribute>
+      <RazorTargetAssemblyAttribute Include="System.Reflection.AssemblyFileVersionAttribute" Condition="'$(RazorAssemblyFileVersion)' != '' and '$(GenerateAssemblyFileVersionAttribute)' == 'true'">
+        <_Parameter1>$(RazorAssemblyFileVersion)</_Parameter1>
+      </RazorTargetAssemblyAttribute>
+      <RazorTargetAssemblyAttribute Include="System.Reflection.AssemblyInformationalVersionAttribute" Condition="'$(RazorAssemblyInformationalVersion)' != '' and '$(GenerateAssemblyInformationalVersionAttribute)' == 'true'">
+        <_Parameter1>$(RazorAssemblyInformationalVersion)</_Parameter1>
+      </RazorTargetAssemblyAttribute>
+      <RazorTargetAssemblyAttribute Include="System.Reflection.AssemblyTitleAttribute" Condition="'$(RazorAssemblyTitle)' != '' and '$(GenerateAssemblyTitleAttribute)' == 'true'">
+        <_Parameter1>$(RazorAssemblyTitle)</_Parameter1>
+      </RazorTargetAssemblyAttribute>
+      <RazorTargetAssemblyAttribute Include="System.Reflection.AssemblyVersionAttribute" Condition="'$(RazorAssemblyVersion)' != '' and '$(GenerateAssemblyVersionAttribute)' == 'true'">
+        <_Parameter1>$(RazorAssemblyVersion)</_Parameter1>
+      </RazorTargetAssemblyAttribute>
+    </ItemGroup>
+
+  </Target>
+
+  <!--
+    To allow version changes to be respected on incremental builds (e.g. through CLI parameters),
+    create a hash of all assembly attributes so that the cache file will change with the calculated
+    assembly attribute values and msbuild will then execute CoreGenerateAssembly to generate a new file.
+  -->
+  <Target Name="_CreateRazorTargetAssemblyInfoInputsCacheFile" Condition="'@(RazorTargetAssemblyAttribute)' != ''">
+
+    <!-- We only use up to _Parameter1 for most attributes, but other targets may add additional assembly attributes with multiple parameters. -->
+    <Hash ItemsToHash="@(RazorTargetAssemblyAttribute->'%(Identity)%(_Parameter1)%(_Parameter2)%(_Parameter3)%(_Parameter4)%(_Parameter5)%(_Parameter6)%(_Parameter7)%(_Parameter8)')">
+      <Output TaskParameter="HashResult" PropertyName="_RazorTargetAssemblyAttributesHash" />
+    </Hash>
+
+    <WriteLinesToFile
+      Lines="$(_RazorTargetAssemblyAttributesHash)"
+      File="$(_RazorTargetAssemblyInfoInputsCacheFile)"
+      Overwrite="True"
+      WriteOnlyWhenDifferent="True" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_RazorTargetAssemblyInfoInputsCacheFile)" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target Name="_CreateRazorAssemblyInfoInputsCacheFile" Condition="'@(_RazorAssemblyAttribute)' != ''">
+
+    <!-- We only use up to _Parameter1 for most attributes, but other targets may add additional assembly attributes with multiple parameters. -->
+    <Hash ItemsToHash="@(_RazorAssemblyAttribute->'%(Identity)%(_Parameter1)%(_Parameter2)%(_Parameter3)%(_Parameter4)%(_Parameter5)%(_Parameter6)%(_Parameter7)%(_Parameter8)')">
+      <Output TaskParameter="HashResult" PropertyName="_RazorAssemblyAttributesHash" />
+    </Hash>
+
+    <WriteLinesToFile
+      Lines="$(_RazorAssemblyAttributesHash)"
+      File="$(_RazorAssemblyInfoInputsCacheFile)"
+      Overwrite="True"
+      WriteOnlyWhenDifferent="True" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_RazorAssemblyInfoInputsCacheFile)" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target
+    Name="_CoreGenerateRazorAssemblyInfo"
+    DependsOnTargets="_CreateRazorAssemblyInfoInputsCacheFile"
+    Inputs="$(_RazorAssemblyInfoInputsCacheFile)"
+    Outputs="$(_RazorAssemblyInfo)"
+    Condition="'@(_RazorAssemblyAttribute)' != ''">
+
+    <ItemGroup Condition="'$(GenerateRazorAssemblyInfo)'=='true'">
+      <Compile Remove="$(_RazorAssemblyInfo)" />
+      <Compile Include="$(_RazorAssemblyInfo)" />
+    </ItemGroup>
+
+    <WriteCodeFragment AssemblyAttributes="@(_RazorAssemblyAttribute)" Language="$(Language)" OutputFile="$(_RazorAssemblyInfo)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_RazorAssemblyInfo)" />
+    </ItemGroup>
+
+  </Target>
+
+  <PropertyGroup>
+    <!-- Generate attributes in the main assembly if we're targeting a C# project and using the Razor Sdk. -->
+    <CoreCompileDependsOn Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(Language)' == 'C#' and '$(GenerateRazorAssemblyInfo)' == 'true'">
+      $(CoreCompileDependsOn);_GenerateRazorAssemblyInfo
+    </CoreCompileDependsOn>
+
+    <_GenerateRazorAssemblyInfoDependsOn>PrepareForBuild;_CoreGenerateRazorAssemblyInfo</_GenerateRazorAssemblyInfoDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_GenerateRazorAssemblyInfo" DependsOnTargets="$(_GenerateRazorAssemblyInfoDependsOn)" />
+
+</Project>

--- a/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.props
+++ b/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Microsoft.NET.Sdk.Razor.props
@@ -1,0 +1,17 @@
+<!--
+***********************************************************************************************
+Microsoft.Net.Sdk.Razor.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+  <PropertyGroup>
+    <RazorSdkCurrentVersionProps>$(MSBuildThisFileDirectory)Sdk.Razor.CurrentVersion.props</RazorSdkCurrentVersionProps>
+    <RazorSdkCurrentVersionTargets>$(MSBuildThisFileDirectory)Sdk.Razor.CurrentVersion.targets</RazorSdkCurrentVersionTargets>
+  </PropertyGroup>
+</Project>

--- a/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Rules/RazorConfiguration.xaml
+++ b/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Rules/RazorConfiguration.xaml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Rule
+  Description="Configuration Properties"
+  DisplayName="Configuration Properties"
+  Name="RazorConfiguration"
+  PageTemplate="generic"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource
+      Persistence="ProjectFile"
+      HasConfigurationCondition="True" 
+      ItemType="RazorConfiguration" />
+  </Rule.DataSource>
+
+  <Rule.Categories>
+    <Category
+      Name="General"
+      DisplayName="General" />
+  </Rule.Categories>
+
+  <StringProperty
+    Category="General"
+    Description="Razor Extensions"
+    DisplayName="Razor Extensions"
+    Name="Extensions"
+    ReadOnly="True"
+    Visible="True" />
+
+</Rule>

--- a/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Rules/RazorExtension.xaml
+++ b/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Rules/RazorExtension.xaml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Rule
+  Description="Extension Properties"
+  DisplayName="Extension Properties"
+  Name="RazorExtension"
+  PageTemplate="generic"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource
+      Persistence="ProjectFile"
+      HasConfigurationCondition="True"
+      ItemType="RazorExtension" />
+  </Rule.DataSource>
+
+  <Rule.Categories>
+    <Category
+      Name="General"
+      DisplayName="General" />
+  </Rule.Categories>
+
+  <StringProperty
+    Category="General"
+    Description="Razor Extension Assembly Name"
+    DisplayName="Razor Extension Assembly Name"
+    Name="AssemblyName"
+    ReadOnly="True"
+    Visible="True" />
+
+  <StringProperty
+    Category="General"
+    Description="Razor Extension Assembly File Path"
+    DisplayName="Razor Extension Assembly File Path"
+    Name="AssemblyFilePath"
+    ReadOnly="True"
+    Visible="True" />
+
+</Rule>

--- a/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Rules/RazorGeneral.xaml
+++ b/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Rules/RazorGeneral.xaml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Rule
+  Description="Razor Properties"
+  DisplayName="Razor Properties"
+  Name="RazorGeneral"
+  PageTemplate="generic"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource
+      Persistence="ProjectFile"
+      HasConfigurationCondition="True" />
+  </Rule.DataSource>
+
+  <Rule.Categories>
+    <Category
+      Name="General"
+      DisplayName="General" />
+  </Rule.Categories>
+
+  <StringProperty
+    Category="General"
+    Description="Razor Language Version"
+    DisplayName="Razor Language Version"
+    Name="RazorLangVersion"
+    ReadOnly="True"
+    Visible="True" />
+
+  <StringProperty
+    Category="General"
+    Description="Razor Configuration Name"
+    DisplayName="Razor Configuration Name"
+    Name="RazorDefaultConfiguration"
+    ReadOnly="True"
+    Visible="True" />
+
+</Rule>

--- a/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
+++ b/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.props
@@ -1,0 +1,77 @@
+<!--
+***********************************************************************************************
+Sdk.Razor.CurrentVersion.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+  <!--
+    Properties and tasks supporting Razor MSBuild integration
+  -->
+
+  <!--
+    Default properties for common Razor SDK behavior.
+  -->
+  <PropertyGroup>
+    <!--
+    Set to true to automatically include certain file types, such as .cshtml files, as content in the project.
+    When referenced via Microsoft.NET.Sdk.Web, this additionally includes all files under wwwroot, and any config files.
+    -->
+    <EnableDefaultContentItems Condition="'$(EnableDefaultContentItems)'==''">true</EnableDefaultContentItems>
+
+    <!--
+      Set to true to automatically include Razor (.cshtml) files in @(RazorGenerate) from @(Content).
+    -->
+    <EnableDefaultRazorGenerateItems Condition="'$(EnableDefaultRazorGenerateItems)'==''">true</EnableDefaultRazorGenerateItems>
+
+    <!--
+      Set to true to copy RazorGenerate items (.cshtml) to the publish directory.
+
+      Typically Razor files are not needed for a published application if they participate in compilation at build-time
+      or publish-time. By default, the Razor SDK will suppress the copying of RazorGenerate items to the publish directory.
+    -->
+    <CopyRazorGenerateFilesToPublishDirectory Condition="'$(CopyRazorGenerateFilesToPublishDirectory)'==''">false</CopyRazorGenerateFilesToPublishDirectory>
+
+    <!--
+      Set to true to copy reference assembly items to the publish directory.
+
+      Typically reference assemblies are not needed for a published application if Razor compilation occurs at build-time
+      or publish-time. By default, the Razor SDK will suppress the copying of reference assemblies to the publish directory.
+    -->
+    <CopyRefAssembliesToPublishDirectory Condition="'$(CopyRefAssembliesToPublishDirectory)'==''">false</CopyRefAssembliesToPublishDirectory>
+
+    <!--
+    Determines the toolset to use to compile Razor (.cshtml) files. Defaults to 'Implicit' to let the Razor Sdk determine the toolset to use.
+    Valid values include 'Implicit', 'RazorSdk', and 'PrecompilationTool'.
+    -->
+    <RazorCompileToolset>Implicit</RazorCompileToolset>
+
+    <!--
+    Configures whether all Razor content items (.cshtml files) will be marked to be included in the produced NuGet package as content.
+
+    All Content items are included in a NuGet package as content files. This setting can be used to control this behavior for Razor content items.
+    -->
+    <IncludeRazorContentInPack Condition="'$(IncludeRazorContentInPack)'==''">false</IncludeRazorContentInPack>
+
+    <!--
+    Configures the file extension used for generated C# files.
+    -->
+    <RazorGenerateOutputFileExtension>.g.cshtml.cs</RazorGenerateOutputFileExtension>
+
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(EnableDefaultItems)' == 'true' And '$(EnableDefaultContentItems)' == 'true'">
+    <Content Include="**\*.cshtml" CopyToPublishDirectory="PreserveNewest" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(DefaultWebContentItemExcludes)">
+      <Pack>$(IncludeRazorContentInPack)</Pack>
+    </Content>
+
+    <None Remove="**\*.cshtml" />
+  </ItemGroup>
+
+</Project>

--- a/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
+++ b/sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/Sdk.Razor.CurrentVersion.targets
@@ -1,0 +1,608 @@
+﻿<!--
+***********************************************************************************************
+Sdk.Razor.CurrentVersion.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+  <!-- 
+    Targets supporting Razor MSBuild integration. Contain support for generating C# code using Razor
+    and including the generated code in the project lifecycle, including compiling, publishing and producing
+    nuget packages.
+  -->
+
+  <!--
+    This is a hook to import a set of targets before the Razor targets. By default this is unused.
+  -->
+  <Import Project="$(CustomBeforeRazorSdkTargets)" Condition="'$(CustomBeforeRazorSdkTargets)' != '' and Exists('$(CustomBeforeRazorSdkTargets)')"/>
+
+  <!--
+    Razor defines two primary targets:
+      'RazorGenerate' - which updates generated code
+      'RazorCompile' - compiles an assembly from generated code
+
+    Use these properties and targets to attach behavior to the corresponding phase.
+  -->
+  <PropertyGroup>
+    <PrepareForRazorGenerateDependsOn>
+      ResolveRazorConfiguration;
+      ResolveRazorGenerateInputs;
+      AssignRazorGenerateTargetPaths;
+      ResolveAssemblyReferenceRazorGenerateInputs;
+      _CheckForMissingRazorCompiler;
+      ResolveTagHelperRazorGenerateInputs
+    </PrepareForRazorGenerateDependsOn>
+
+    <RazorGenerateDependsOn>
+      PrepareForRazorGenerate;
+      _CheckForMissingRazorCompiler;
+      RazorCoreGenerate
+    </RazorGenerateDependsOn>
+  
+    <PrepareForRazorCompileDependsOn>
+      RazorGenerate;
+      ResolveRazorCompileInputs;
+      GenerateRazorTargetAssemblyInfo
+    </PrepareForRazorCompileDependsOn>
+
+    <ResolveRazorCompileInputsDependsOn>
+      ResolveRazorEmbeddedResources
+    </ResolveRazorCompileInputsDependsOn>
+
+    <RazorCompileDependsOn>
+      PrepareForRazorCompile;
+      RazorCoreCompile
+    </RazorCompileDependsOn>
+
+    <BuiltProjectOutputGroupDependsOn>
+      $(BuiltProjectOutputGroupDependsOn);
+      _RazorAddBuiltProjectOutputGroupOutput
+    </BuiltProjectOutputGroupDependsOn>
+
+    <DebugSymbolsProjectOutputGroupDependsOn>
+      $(DebugSymbolsProjectOutputGroupDependsOn);
+      _RazorAddDebugSymbolsProjectOutputGroupOutput
+    </DebugSymbolsProjectOutputGroupDependsOn>
+
+    <PrepareForBuildDependsOn>
+      $(PrepareForBuildDependsOn);
+      ResolveRazorGenerateInputs
+    </PrepareForBuildDependsOn>
+
+    <PrepareForRunDependsOn>
+      _RazorPrepareForRun;
+      $(PrepareForRunDependsOn)
+    </PrepareForRunDependsOn>
+
+    <GetCopyToOutputDirectoryItemsDependsOn>
+      _RazorGetCopyToOutputDirectoryItems;
+      $(GetCopyToOutputDirectoryItems)
+    </GetCopyToOutputDirectoryItemsDependsOn>
+
+  </PropertyGroup>
+
+  <!-- 
+    Default values for properties that affect Razor targets to the standard build lifecycle.
+  -->
+  <PropertyGroup Condition="'$(RazorCompileOnBuild)'=='' AND '$(Language)'=='C#'">
+    <RazorCompileOnBuild>true</RazorCompileOnBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(RazorCompileOnPublish)'=='' AND '$(Language)'=='C#'">
+    <!-- Always compile on publish by default if we're compiling on build -->
+    <RazorCompileOnPublish Condition="'$(RazorCompileOnBuild)'=='true'">true</RazorCompileOnPublish>
+
+    <!-- Compatibility with the old MVC Precompilation setting -->
+    <RazorCompileOnPublish Condition="'$(RazorCompileOnPublish)'==''">$(MvcRazorCompileOnPublish)</RazorCompileOnPublish>
+
+    <!-- Default to on if MvcRazorCompileOnPublish isn't set for some reason -->
+    <RazorCompileOnPublish Condition="'$(RazorCompileOnPublish)'==''">true</RazorCompileOnPublish>
+  </PropertyGroup>
+
+  <!--
+    Properties that configure Razor SDK, but need to be defined in targets due to evaluation order.
+  -->
+  <PropertyGroup>
+    <!-- Output directory used for generated files -->
+    <RazorGenerateIntermediateOutputPath Condition="'$(RazorGenerateIntermediateOutputPath)'==''">$(IntermediateOutputPath)Razor\</RazorGenerateIntermediateOutputPath>
+
+    <!-- Suffix appended to $(TargetName) to produce $(RazorTargetName), the name of the assembly produced by Razor -->
+    <RazorTargetNameSuffix Condition="'$(RazorTargetNameSuffix)' == ''">.Razor</RazorTargetNameSuffix>
+    
+    <!-- File name (without extension) of the assembly produced by Razor -->
+    <RazorTargetName Condition="'$(RazorTargetName)'==''">$(TargetName)$(RazorTargetNameSuffix)</RazorTargetName>
+
+   <!--
+      The compatibility zone - these properties were provided by the MVC Precompilation tool and they
+      map to supported settings in Razor SDK.
+
+      We want to set the defaults for these in the .props file, but we need to process the old settings here
+      in case they were set in the project file. The consequence of this is that the old settings will override
+      the new ones if they are set to conflicting values.
+    -->
+    <CopyRazorGenerateFilesToPublishDirectory Condition="'$(MvcRazorExcludeViewFilesFromPublish)'=='true'">false</CopyRazorGenerateFilesToPublishDirectory>
+    <CopyRazorGenerateFilesToPublishDirectory Condition="'$(MvcRazorExcludeViewFilesFromPublish)'=='false'">true</CopyRazorGenerateFilesToPublishDirectory>
+
+    <CopyRefAssembliesToPublishDirectory Condition="'$(MvcRazorExcludeRefAssembliesFromPublish)'=='true'">false</CopyRefAssembliesToPublishDirectory>
+    <CopyRefAssembliesToPublishDirectory Condition="'$(MvcRazorExcludeRefAssembliesFromPublish)'=='false'">true</CopyRefAssembliesToPublishDirectory>
+
+    <!-- 
+      We can't set the actual default value here due to evaluation order (depends on $(OutDir)).
+      
+      This handles a compatibility case with MVC Precompilation.
+    -->
+    <RazorOutputPath Condition="'$(MvcRazorOutputPath)'!=''">$([MSBuild]::EnsureTrailingSlash('$(MvcRazorOutputPath)'))</RazorOutputPath>
+
+    <!--
+      Configures whether all of the @(RazorGenerate) items will be added as embedded files to the produced assembly.
+
+      When true, everything in @(RazorGenerate) will be added to @(RazorEmbeddedFiles) and passed to CSC.  
+    -->
+    <EmbedRazorGenerateSources Condition="'$(MvcRazorEmbedViewSources)'!=''">$(MvcRazorEmbedViewSources)</EmbedRazorGenerateSources>
+    <EmbedRazorGenerateSources Condition="'$(EmbedRazorGenerateSources)'==''">false</EmbedRazorGenerateSources>
+
+    <!--
+    Set to false to disable Razor code generation from using a persistent build server process.
+    -->
+    <UseRazorBuildServer Condition="'$(UseRazorBuildServer)'==''">$(UseSharedCompilation)</UseRazorBuildServer>
+    <UseRazorBuildServer Condition="'$(UseRazorBuildServer)'==''">true</UseRazorBuildServer>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Similar to https://github.com/Microsoft/msbuild/blob/908cc9ccd4961441628f68e37a148183a87bb067/src/Tasks/Microsoft.Common.CurrentVersion.targets#L146-L153 -->
+    <_RazorDebugSymbolsProduced>false</_RazorDebugSymbolsProduced>
+    <_RazorDebugSymbolsProduced Condition="'$(DebugSymbols)'=='true'">true</_RazorDebugSymbolsProduced>
+    <_RazorDebugSymbolsProduced Condition="'$(DebugType)'=='none'">false</_RazorDebugSymbolsProduced>
+    <_RazorDebugSymbolsProduced Condition="'$(DebugType)'=='pdbonly'">true</_RazorDebugSymbolsProduced>
+    <_RazorDebugSymbolsProduced Condition="'$(DebugType)'=='full'">true</_RazorDebugSymbolsProduced>
+    <_RazorDebugSymbolsProduced Condition="'$(DebugType)'=='portable'">true</_RazorDebugSymbolsProduced>
+    <_RazorDebugSymbolsProduced Condition="'$(DebugType)'=='embedded'">false</_RazorDebugSymbolsProduced>
+  </PropertyGroup>
+
+  <!-- Resolve the toolset to use -->
+  <PropertyGroup>
+    <!-- Default value for the property 'MvcRazorCompileOnPublish' is empty. If it has been explicitly enabled, continue using precompilation. -->
+    <ResolvedRazorCompileToolset Condition="'$(MvcRazorCompileOnPublish)' == 'true'">PrecompilationTool</ResolvedRazorCompileToolset>
+
+    <!-- The default value for 'RazorCompileToolset' was not modified. In this case, infer the toolset to use as RazorSdk. -->
+    <ResolvedRazorCompileToolset Condition="'$(MvcRazorCompileOnPublish)' == '' AND '$(RazorCompileToolset)' == 'Implicit'">RazorSdk</ResolvedRazorCompileToolset>
+
+    <ResolvedRazorCompileToolset Condition="'$(MvcRazorCompileOnPublish)' == '' AND '$(RazorCompileToolset)' == 'PrecompilationTool'">$(RazorCompileToolset)</ResolvedRazorCompileToolset>
+    <ResolvedRazorCompileToolset Condition="'$(MvcRazorCompileOnPublish)' == '' AND '$(RazorCompileToolset)' == 'RazorSdk'">$(RazorCompileToolset)</ResolvedRazorCompileToolset>
+
+    <!-- If RazorSdk is not referenced, fall-back to Precompilation tool -->
+    <ResolvedRazorCompileToolset Condition="'$(ResolvedRazorCompileToolset)' == 'RazorSdk' And '$(IsRazorCompilerReferenced)' != 'true'">PrecompilationTool</ResolvedRazorCompileToolset>
+
+    <!-- Previous versions of the precompilation tool still depends on the msbuild property 'MvcRazorCompileOnPublish'. Hence, setting it to the old default value -->
+    <MvcRazorCompileOnPublish Condition="'$(MvcRazorCompileOnPublish)' == ''">true</MvcRazorCompileOnPublish>
+  </PropertyGroup>
+
+  <!--
+    Properties that configure Razor SDK, but need to be defined in targets due to evaluation order.
+  -->
+  <ItemGroup>
+    <!-- Used to creating the final compiled Razor dll -->
+    <RazorIntermediateAssembly Condition="'$(RazorIntermediateAssembly)'==''" Include="$(IntermediateOutputPath)$(RazorTargetName).dll" />
+    <!-- Used in Compilation.targets -->   
+    <_RazorDebugSymbolsIntermediatePath Condition="'$(_RazorDebugSymbolsProduced)'=='true'" Include="$(IntermediateOutputPath)$(RazorTargetName).pdb" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      Add all cshtml files to UpToDateCheckInput - a collection of files used by FastUpToDateCheck to determine
+      if any of the the project inputs have changed.
+    -->
+    <UpToDateCheckInput Condition="'$(RazorCompileOnBuild)'=='true'" Include="@(Content->WithMetadataValue('Extension', '.cshtml'))" />
+
+    <!--
+      Add Razor output files to UpToDateCheckBuilt - a collection of files used by FastUpToDateCheck to determine
+      if any of the project's outputs have changed.
+    -->
+    <UpToDateCheckBuilt Include="@(RazorIntermediateAssembly)"
+      Condition="'$(RazorCompileOnBuild)'=='true' AND '@(Content->WithMetadataValue('Extension', '.cshtml'))' != ''" />
+  </ItemGroup>
+
+
+  <!--
+    These are the targets that generate code using Razor, separated from the main file for ease of maintenance.
+    Most targets related to Razor code generation are defined there.
+  -->
+  <Import Project="$(RazorCodeGenerationTargetsPath)"
+    Condition="'$(RazorCodeGenerationTargetsPath)' != '' AND Exists('$(RazorCodeGenerationTargetsPath)')" />
+
+  <Import Project="Microsoft.NET.Sdk.Razor.GenerateAssemblyInfo.targets" />
+
+  <!-- 
+    These are the targets that actually do compilation using CSC, separated from the main file for ease of maintenance.
+
+    RazorCoreCompile should be defined there.
+  -->
+  <Import Project="Microsoft.NET.Sdk.Razor.Compilation.targets" />
+
+  <Target Name="PrepareForRazorGenerate" DependsOnTargets="$(PrepareForRazorGenerateDependsOn)">
+  </Target>
+
+  <Target Name="RazorGenerate" DependsOnTargets="$(RazorGenerateDependsOn)">
+  </Target>
+
+  <Target Name="PrepareForRazorCompile" DependsOnTargets="$(PrepareForRazorCompileDependsOn)">
+  </Target>
+
+  <Target Name="RazorCompile" DependsOnTargets="$(RazorCompileDependsOn)">
+  </Target>
+
+  <!-- 
+    Computes the applicable @(ResolvedRazorConfiguration) and @(ResolvedRazorExtension) items that match the project's
+    configuration. 
+  -->
+  <Target 
+    Name="ResolveRazorConfiguration"
+    Condition="'$(RazorDefaultConfiguration)'!=''">
+
+    <ItemGroup>
+      <ResolvedRazorConfiguration Include="@(RazorConfiguration)" Condition="'%(RazorConfiguration.Identity)'=='$(RazorDefaultConfiguration)'" />
+    </ItemGroup>
+
+    <FindInList List="@(RazorExtension)" ItemSpecToFind="@(RazorConfiguration->Metadata('Extensions'))">
+      <Output TaskParameter="ItemFound" ItemName="ResolvedRazorExtension" />
+    </FindInList>
+  </Target>
+
+  <!--
+    Gets assembly attributes in support for Razor runtime code generation. This is a set of standard
+    metadata attributes (defined in Microsoft.AspNetCore.Razor.Runtime) that capture the build-time
+    Razor configuration of an application to be used at runtime.
+    
+    This allows the project file to act as the source of truth for the applicable Razor configuration regardless 
+    of how Razor is used.
+
+    The SDK expects configurations that use runtime compilation to set $(GenerateRazorHostingAssemblyInfo) to true,
+    it will be unset by default.
+  -->
+  <PropertyGroup>
+    <_GenerateRazorAssemblyInfoDependsOn>RazorGetAssemblyAttributes;$(_GenerateRazorAssemblyInfoDependsOn)</_GenerateRazorAssemblyInfoDependsOn>
+  </PropertyGroup>
+
+  <Target 
+    Name="RazorGetAssemblyAttributes"
+    Condition="'$(GenerateRazorHostingAssemblyInfo)'=='true' and '$(RazorDefaultConfiguration)'!=''"
+    DependsOnTargets="ResolveRazorConfiguration">
+    <ItemGroup>
+      <_RazorAssemblyAttribute Include="Microsoft.AspNetCore.Razor.Hosting.RazorLanguageVersionAttribute">
+        <_Parameter1>$(RazorLangVersion)</_Parameter1>
+      </_RazorAssemblyAttribute>
+      <_RazorAssemblyAttribute Include="Microsoft.AspNetCore.Razor.Hosting.RazorConfigurationNameAttribute">
+        <_Parameter1>$(RazorDefaultConfiguration)</_Parameter1>
+      </_RazorAssemblyAttribute>
+      <_RazorAssemblyAttribute Include="Microsoft.AspNetCore.Razor.Hosting.RazorExtensionAssemblyNameAttribute" Condition="'%(ResolvedRazorExtension.AssemblyName)'!=''">
+        <_Parameter1>%(ResolvedRazorExtension.Identity)</_Parameter1>
+        <_Parameter2>%(ResolvedRazorExtension.AssemblyName)</_Parameter2>
+      </_RazorAssemblyAttribute>
+    </ItemGroup>
+
+  </Target>
+
+  <!--
+    Gathers input source files for code generation. This is a separate target so that we can avoid
+    lots of work when there are no inputs for code generation.
+    This target runs as part of PrepareForBuild. This gives us an opportunitity to change things like CopyToPublishDirectory
+    for Content items before they are processed by other Build targets.
+
+    NOTE: This target is called as part of an incremental build scenario in VS. Do not perform any work
+    outside of calculating RazorGenerate items in this target.
+  -->
+  <Target Name="ResolveRazorGenerateInputs">
+    <!--
+      In MVC Precompilation MvcRazorFilesToCompile also had the effect of suppressing the default
+      items for Razor code generation. As with all of these MVC Precompilation back-compat settings,
+      using the old thing, overrides the new thing.
+    -->
+    <PropertyGroup Condition="'@(MvcRazorFilesToCompile)'!=''">
+      <EnableDefaultRazorGenerateItems>false</EnableDefaultRazorGenerateItems>
+    </PropertyGroup>
+    <ItemGroup>
+      <RazorGenerate Include="@(MvcRazorFilesToCompile)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(EnableDefaultRazorGenerateItems)'=='true'">
+      <RazorGenerate Include="@(Content)" Condition="'%(Content.Extension)'=='.cshtml'" />
+    </ItemGroup>
+
+    <!--
+      Ideally we want to able to update all Content items that also appear in RazorGenerate to have
+      CopyToPublishDirectory=Never. However, there isn't a simple way to do this (https://github.com/Microsoft/msbuild/issues/1618). 
+      Instead, we'll update all cshtml Content items when EnableDefaultRazorGenerateItems=true and Razor Sdk is used for publishing.
+    -->
+    <ItemGroup Condition="
+      '$(EnableDefaultRazorGenerateItems)'=='true' and 
+      '$(CopyRazorGenerateFilesToPublishDirectory)'=='false' and 
+      '$(ResolvedRazorCompileToolset)'=='RazorSdk' and 
+      '$(RazorCompileOnPublish)'=='true'">
+      
+      <Content Condition="'%(Content.Extension)'=='.cshtml'" CopyToPublishDirectory="Never" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AssignRazorGenerateTargetPaths" Condition="'@(RazorGenerate)' != ''">
+    <AssignTargetPath Files="@(RazorGenerate)" RootFolder="$(MSBuildProjectDirectory)">
+      <Output TaskParameter="AssignedFiles" ItemName="RazorGenerateWithTargetPath" />
+    </AssignTargetPath>
+
+    <ItemGroup>
+      <RazorGenerateWithTargetPath Condition="'%(RazorGenerateWithTargetPath.GeneratedOutput)' == ''">
+        <GeneratedOutput>$(RazorGenerateIntermediateOutputPath)$([System.IO.Path]::ChangeExtension('%(RazorGenerateWithTargetPath.TargetPath)', '$(RazorGenerateOutputFileExtension)'))</GeneratedOutput>
+      </RazorGenerateWithTargetPath>
+    </ItemGroup>
+  </Target>
+
+  <!-- 
+    Gathers input assemblies for Tag Helper discovery and compilation. Add items to @(ReferencePath)
+  -->
+  <Target
+    Name="ResolveAssemblyReferenceRazorGenerateInputs"
+    DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <RazorReferencePath Include="@(ReferencePath)"/>
+      <RazorReferencePath Include="$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)$(TargetName)$(TargetExt)'))"/>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Gathers inputs to the RazorCoreCompile target into the @(RazorCompile) itemgroup.
+
+    This is marker target so that the code generation targets can attach.
+  -->
+  <Target Name="ResolveRazorCompileInputs" DependsOnTargets="$(ResolveRazorCompileInputsDependsOn)">
+  </Target>
+
+  <Target Name="ResolveRazorEmbeddedResources" Condition="'$(EmbedRazorGenerateSources)'=='true'">
+    <ItemGroup>
+      <RazorEmbeddedResource Include="@(RazorGenerateWithTargetPath)">
+        <LogicalName>/$([System.String]::Copy('%(RazorGenerateWithTargetPath.TargetPath)').Replace('\','/'))</LogicalName>
+        <Type>Non-Resx</Type>
+        <WithCulture>false</WithCulture>
+      </RazorEmbeddedResource>
+
+      <!-- Similar to _GenerateCompileInputs -->
+      <_RazorCoreCompileResourceInputs
+        Include="@(RazorEmbeddedResource)"
+        Condition="'%(RazorEmbeddedResource.WithCulture)'=='false' and '%(RazorEmbeddedResource.Type)'=='Non-Resx' " />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    This target is called after PrepareForPublish when RazorCompileOnPublish=true so that we can hook into publish.
+    This target just hooks up other targets since Publish and PrepareForPublish don't have a DependsOnTargets
+    property we can use. 
+  -->
+  <Target 
+    Name="_RazorPrepareForPublish"
+    AfterTargets="PrepareForPublish"
+    DependsOnTargets="RazorCompile"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnPublish)'=='true'">
+  </Target>
+
+  <!--
+    This target adds the Razor assembly to the BuiltProjectOutputGroupOutput - which is used as input to the Pack target.
+  -->
+  <Target 
+    Name="_RazorAddBuiltProjectOutputGroupOutput"
+    DependsOnTargets="_ResolveRazorTargetPath;ResolveRazorGenerateInputs"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
+
+    <ItemGroup Condition="'@(RazorGenerate)'!= ''">
+      <BuiltProjectOutputGroupOutput Include="%(RazorIntermediateAssembly.FullPath)" FinalOutputPath="$(RazorTargetPath)" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target
+    Name="_RazorAddDebugSymbolsProjectOutputGroupOutput"
+    DependsOnTargets="_ResolveRazorTargetPath;ResolveRazorGenerateInputs"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
+
+    <ItemGroup Condition="Exists('@(_RazorDebugSymbolsIntermediatePath)')">
+      <DebugSymbolsProjectOutputGroupOutput Include="%(_RazorDebugSymbolsIntermediatePath.FullPath)" FinalOutputPath="$(RazorTargetDir)$(RazorTargetName).pdb" />
+    </ItemGroup>
+    
+  </Target>
+
+  <!--
+    Set up RazorCompile to run before PrepareForRun. This should ensure that the Razor dll and pdbs are available to be copied
+    as part of GetCopyToOutputDirectoryItems which is invoked during PrepareForRun.
+  -->
+  <Target
+    Name="_RazorPrepareForRun"
+    DependsOnTargets="RazorCompile"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'" />
+
+  <!--
+    Called as part of GetCopyToOutputDirectoryItems - this target populates the list of items that get
+    copied to the output directory when building as a project reference.
+  -->
+  <Target 
+    Name="_RazorGetCopyToOutputDirectoryItems"
+    DependsOnTargets="ResolveRazorGenerateInputs"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
+
+    <!-- 
+      This condition needs to be inside the target because it the itemgroup will be populated after the target's
+      condition is evaluated.
+    -->
+    <ItemGroup Condition="'@(RazorGenerate)'!=''">
+      <AllItemsFullPathWithTargetPath Include="@(RazorIntermediateAssembly->'%(FullPath)')">
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </AllItemsFullPathWithTargetPath>
+      <AllItemsFullPathWithTargetPath Include="@(_RazorDebugSymbolsIntermediatePath->'%(FullPath)')">
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </AllItemsFullPathWithTargetPath>
+    </ItemGroup>
+
+  </Target>
+
+  <!--
+    Called as part of GetCopyToPublishDirectoryItems - this target populates the list of items that get
+    copied to the publish directory when publishing as a project reference.
+
+    The dependency on RazorCompile is needed because this will be called during publish on each P2P
+    reference without calling RazorCompile for the P2P references.
+  -->
+  <Target
+    Name="_RazorGetCopyToPublishDirectoryItems"
+    BeforeTargets="GetCopyToPublishDirectoryItems"
+    DependsOnTargets="RazorCompile"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnPublish)'=='true'">
+
+    <!-- 
+      This condition needs to be inside the target because it the itemgroup will be populated after the target's
+      condition is evaluated.
+    -->
+    <ItemGroup Condition="'@(RazorGenerate)'!=''">
+      <AllPublishItemsFullPathWithTargetPath Include="@(RazorIntermediateAssembly->'%(FullPath)')">
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </AllPublishItemsFullPathWithTargetPath>
+      <AllPublishItemsFullPathWithTargetPath Include="@(_RazorDebugSymbolsIntermediatePath->'%(FullPath)')">
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </AllPublishItemsFullPathWithTargetPath>
+    </ItemGroup>
+
+  </Target>
+
+  <!--
+    Called as part of CopyFilesToOutputDirectory - this target is called when building the project to copy
+    files to the output directory.
+  -->
+  <Target 
+    Name="_RazorCopyFilesToOutputDirectory" 
+    DependsOnTargets="_ResolveRazorTargetPath;RazorCompile"
+    AfterTargets="CopyFilesToOutputDirectory"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnBuild)'=='true'">
+
+    <!-- Copy the Razor dll  -->
+    <Copy
+      SourceFiles="@(RazorIntermediateAssembly)"
+      DestinationFiles="$(RazorTargetPath)"
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)"
+      UseSymboliclinksIfPossible="$(CreateSymbolicLinksForCopyFilesToOutputDirectoryIfPossible)"
+      Condition="Exists('@(RazorIntermediateAssembly)') and '$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)' != 'true'">
+
+      <Output TaskParameter="DestinationFiles" ItemName="_RazorAssembly"/>
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+    </Copy>
+
+    <Message 
+      Importance="High" 
+      Text="$(MSBuildProjectName) -&gt; @(_RazorAssembly->'%(FullPath)')" 
+      Condition="Exists('@(RazorIntermediateAssembly)') and '$(CopyBuildOutputToOutputDirectory)' == 'true' and '$(SkipCopyBuildProduct)'!='true'" />
+
+    <!-- Copy the Razor debug information file (.pdb), if any -->
+    <Copy
+      SourceFiles="@(_RazorDebugSymbolsIntermediatePath)"
+      DestinationFolder="$(RazorOutputPath)"
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)"
+      UseSymboliclinksIfPossible="$(CreateSymbolicLinksForCopyFilesToOutputDirectoryIfPossible)"
+      Condition="Exists('@(_RazorDebugSymbolsIntermediatePath)') and '$(SkipCopyingSymbolsToOutputDirectory)' != 'true' and '$(CopyOutputSymbolsToOutputDirectory)'=='true'">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
+    </Copy>
+
+    <!--
+    FastUpToDate check in VS does not consider the Views dll when determining if referencing projects need to be rebuilt.
+    We'll touch a marker file that is used during as input for up to date check. Based on
+    https://github.com/Microsoft/msbuild/blob/637f06e31ef46892faeb40044899a62a15b77f79/src/Tasks/Microsoft.Common.CurrentVersion.targets#L4364-L4368
+    -->
+    <Touch Files="@(CopyUpToDateMarker)" AlwaysCreate="true" Condition="'@(_RazorAssembly)' != ''">
+      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
+    </Touch>
+    
+  </Target>
+
+  <!--
+    Called after ComputeFilesToPublish and ComputeRefAssembliesToPublish but before CopyFilesToPublishDirectory - this target is called when 
+    publishing the project to get a list of files to the output directory.
+  -->
+  <Target
+    Name="_RazorComputeFilesToPublish"
+    AfterTargets="ComputeRefAssembliesToPublish"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnPublish)'=='true' and '@(RazorGenerate)'!=''">
+
+    <!-- If we generated an assembly/pdb then include those -->
+    <ItemGroup>
+      <ResolvedFileToPublish Include="@(RazorIntermediateAssembly)" Condition="'$(CopyBuildOutputToPublishDirectory)'=='true'">
+        <RelativePath>@(RazorIntermediateAssembly->'%(Filename)%(Extension)')</RelativePath>
+      </ResolvedFileToPublish>
+      <ResolvedFileToPublish Include="@(_RazorDebugSymbolsIntermediatePath)" Condition="'$(CopyOutputSymbolsToPublishDirectory)'=='true'">
+        <RelativePath>@(_RazorDebugSymbolsIntermediatePath->'%(Filename)%(Extension)')</RelativePath>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+
+    <!--
+      RazorGenerate items are usually populated from the '.cshtml' files in @(Content). These are published by default
+      so all we need to do is exclude them. 
+    -->
+    <ItemGroup Condition="'$(CopyRazorGenerateFilesToPublishDirectory)'=='false'">
+      <ResolvedFileToPublish Remove="%(RazorGenerate.FullPath)"/>
+    </ItemGroup>
+  </Target>
+
+  <Target
+    Name="_RazorRemoveRefAssembliesFromPublish"
+    AfterTargets="ComputeRefAssembliesToPublish"
+    Condition="'$(ResolvedRazorCompileToolset)'=='RazorSdk' and '$(RazorCompileOnPublish)'=='true' and '$(CopyRefAssembliesToPublishDirectory)'=='false'">
+    <!--
+      The ref assemblies are published whenever PreserveCompilationContext is true, which we expect to be true for
+      most usages of Razor. There's no setting that excludes just the ref assemblies, so we do it ourselves. 
+    -->
+    <ItemGroup>
+      <ResolvedFileToPublish 
+        Remove="%(ResolvedFileToPublish.Identity)"
+        Condition="'%(ResolvedFileToPublish.RelativePath)'=='$(RefAssembliesFolderName)\%(Filename)%(Extension)'"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_CheckForMissingRazorCompiler" Condition="'$(IsRazorCompilerReferenced)' != 'true'">
+    <Error
+      Text="A PackageReference for 'Microsoft.AspNetCore.Razor.Design' was not included in your project. This package is required to compile Razor files. Typically, a
+      transitive reference to 'Microsoft.AspNetCore.Razor.Design' and references required to compile Razor files are obtained by adding a PackageReference
+      for 'Microsoft.AspNetCore.Mvc' in your project. For more information, see https://go.microsoft.com/fwlink/?linkid=868374." />
+  </Target>
+
+  <Target Name="_ResolveRazorTargetPath">
+    <PropertyGroup>
+      <RazorOutputPath Condition="'$(RazorOutputPath)'==''">$([MSBuild]::EnsureTrailingSlash('$(OutDir)'))</RazorOutputPath>
+      <RazorTargetDir>$([MSBuild]::Escape($([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(RazorOutputPath)'))'))))))</RazorTargetDir>
+      <!-- Example, c:\MyProjects\MyProject\bin\debug\MyAssembly.Views.dll -->
+      <RazorTargetPath Condition=" '$(RazorTargetPath)' == '' ">$(RazorTargetDir)$(RazorTargetName).dll</RazorTargetPath>
+    </PropertyGroup>
+  </Target>
+
+  <PropertyGroup Condition="'$(RazorDesignTimeTargets)'==''">
+    <RazorDesignTimeTargets>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Razor\Microsoft.NET.Sdk.Razor.DesignTime.targets</RazorDesignTimeTargets>
+    <RazorDesignTimeTargets Condition="!Exists('$(RazorDesignTimeTargets)')">$(MSBuildThisFileDirectory)Microsoft.NET.Sdk.Razor.DesignTime.targets</RazorDesignTimeTargets>
+  </PropertyGroup>
+
+  <Import Project="$(RazorDesignTimeTargets)" />
+
+  <!--
+    This is a hook to import a set of targets after the Razor targets. By default this is unused.
+  -->
+  <Import Project="$(CustomAfterRazorSdkTargets)" Condition="'$(CustomAfterRazorSdkTargets)' != '' and Exists('$(CustomAfterRazorSdkTargets)')"/>
+
+</Project>

--- a/sdks/Microsoft.NET.Sdk.Razor/buildMultiTargeting/Microsoft.NET.Sdk.Razor.props
+++ b/sdks/Microsoft.NET.Sdk.Razor/buildMultiTargeting/Microsoft.NET.Sdk.Razor.props
@@ -1,0 +1,17 @@
+<!--
+***********************************************************************************************
+Microsoft.Net.Sdk.Razor.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+  <PropertyGroup>
+    <RazorSdkCurrentVersionProps>$(MSBuildThisFileDirectory)..\build\netstandard2.0\Sdk.Razor.CurrentVersion.props</RazorSdkCurrentVersionProps>
+    <RazorSdkCurrentVersionTargets>$(MSBuildThisFileDirectory)Sdk.Razor.CurrentVersion.MultiTargeting.targets</RazorSdkCurrentVersionTargets>
+  </PropertyGroup>
+</Project>

--- a/sdks/Microsoft.NET.Sdk.Razor/buildMultiTargeting/Sdk.Razor.CurrentVersion.MultiTargeting.targets
+++ b/sdks/Microsoft.NET.Sdk.Razor/buildMultiTargeting/Sdk.Razor.CurrentVersion.MultiTargeting.targets
@@ -1,0 +1,22 @@
+﻿<!--
+***********************************************************************************************
+Sdk.Razor.CurrentVersion.MultiTargeting.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0">
+
+  <Target Name="RazorCompile">
+    <Error Text="The 'RazorCompile' target is not supported without specifying a target framework. The current project targets multiple frameworks, please specify a framework to execute this target." />
+  </Target>
+
+  <Target Name="RazorGenerate">
+    <Error Text="The 'RazorGenerate' target is not supported without specifying a target framework. The current project targets multiple frameworks, please specify a framework to execute this target." />
+  </Target>
+
+</Project>


### PR DESCRIPTION
Missed committing the sdk files in
3f830707fb426a3b10db18ee94e5bd07a99871bb !

cli commit: d36e5ce1619640f4516c1e89ef20cf52f1a32878

Microsoft.NET.Sdk.Razor: 2.1.0

Version from:
    https://github.com/dotnet/cli/blob/d36e5ce1619640f4516c1e89ef20cf52f1a32878/build/DependencyVersions.props

(A future fix should guard against this kinda mistake)

Fixes https://github.com/mono/mono/issues/11214 .