### PR TITLE
PR to bump roslyn dependency to new version

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,6 +1,8 @@
 <Project>
 
   <PropertyGroup>
+      <MicrosoftNetCompilersVersion>3.1.0-beta1-19162-08</MicrosoftNetCompilersVersion>
+      <CompilerToolsVersion>3.1.0-beta1-19162-08</CompilerToolsVersion>
       <MicrosoftNETCoreCompilersVersion>2.10.0</MicrosoftNETCoreCompilersVersion>
       <NuGetPackageVersion Condition="'$(NuGetPackageVersion)' == ''">4.8.0-rtm.5362</NuGetPackageVersion>
       <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>

--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 configuration="debug"
 host_type="core"


### PR DESCRIPTION
This bumps the version of the roslyn package dependency used by msbuild to the version we intend to bump mono to.

I was able to successfully build using cibuild_bootstrapped_msbuild.sh after this in a clean checkout and observe that the correct version of the package was pulled into .packages and the incorrect version was not. MSBuild.dll built correctly.