### PR TITLE
[mono] Change makefile arg `MSBUILD_PROPERTIES` -> `ARGS`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all-mono:
-	./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --binaryLog --skip_tests ${MSBUILD_PROPERTIES}
+	./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --binaryLog --skip_tests ${ARGS}
 
 test-mono:
-	./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --binaryLog ${MSBUILD_PROPERTIES}
+	./eng/cibuild_bootstrapped_msbuild.sh --host_type mono --configuration Release --binaryLog ${ARGS}
 
 clean-%: clean
 

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Mono-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Mono-MSBuild.md
@@ -22,7 +22,7 @@ MSBuild requires a stable version of [Mono](http://www.mono-project.com/download
 
 To pass any extra properties to the build:
 
-`make MSBUILD_PROPERTIES="/p:Foo=Bar"`
+`make ARGS="/p:Foo=Bar"`
 
 ## Getting Mono MSBuild binaries without building the code ##
 The best way to get Mono MSBuild for OSX/macOS is to get the official [Mono package](http://www.mono-project.com/download/#download-mac). After installing it, you can run `msbuild`.


### PR DESCRIPTION
.. because this is passed to the `cibuild_bootstrapped_build.sh` script
which has it's own set of parameters.