### PR TITLE
Forcibly disable compiler server under all circumstances

### DIFF
--- a/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
+++ b/src/Tasks/RoslynCodeTaskFactory/RoslynCodeTaskFactoryCompilers.cs
@@ -61,7 +61,15 @@ namespace Microsoft.Build.Tasks
 
         public string TargetType { get; set; }
 
-        public bool? UseSharedCompilation { get; set; }
+        // FIXME: Workaround for https://github.com/mono/mono/issues/11939 - kg
+        public bool? UseSharedCompilation {
+            get {
+                return false;
+            }
+            set {
+                return;
+            }
+        }
 
         protected virtual string ReferenceSwitch => "/reference:";
 


### PR DESCRIPTION
Workaround for https://github.com/mono/mono/issues/11939, because our previous measures to disable the compiler server don't seem to actually work.
We can't allow it to be enabled on random versions of mono since we have no way to know whether they are actually compatible with the compiler server. Many versions are not.