### PR TITLE
[mono] Do not disable use of shared compiler

### DIFF
--- a/src/Tasks/Microsoft.CSharp.Mono.targets
+++ b/src/Tasks/Microsoft.CSharp.Mono.targets
@@ -42,7 +42,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
         <_ConfigurationNameTmp>$(ConfigurationName)</_ConfigurationNameTmp>
         <_ConfigurationNameTmp Condition="'$(ConfigurationName)' == ''">$(Configuration)</_ConfigurationNameTmp>
 
-        <UseSharedCompilation Condition="'$(UseSharedCompilation)' == ''">false</UseSharedCompilation>
         <CscToolPath Condition="'$(CscToolPath)' == '' and '$(CscToolExe)' == 'mcs.exe'">$(MSBuildFrameworkToolsPath)</CscToolPath>
         <DebugType Condition="'$(OS)' != 'Windows_NT' And ('$(DebugSymbols)'=='True' or ('$(DebugSymbols)'=='' And '$(_ConfigurationNameTmp)'=='Debug'))">portable</DebugType>
     </PropertyGroup>


### PR DESCRIPTION
- this would allow the default behavior to come into effect, which should be to use the shared compiler in most cases