### PR TITLE
[mono] Update build scripts to track upstream changes

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -21,5 +21,6 @@
     <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
     <add key="roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+
   </packageSources>
 </configuration>

--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -63,6 +63,7 @@ function DownloadMSBuildForMono {
 
 RepoRoot="$ScriptRoot/.."
 artifacts_dir="$RepoRoot/artifacts"
+Stage1Dir="$RepoRoot/stage1"
 
 mono_msbuild_dir="$artifacts_dir/mono-msbuild"
 msbuild_download_url="https://github.com/mono/msbuild/releases/download/0.07/mono_msbuild_xplat-master-8f608e49.zip"
@@ -89,9 +90,7 @@ then
 	/bin/bash "$ScriptRoot/common/build.sh" $run_restore --build --ci --configuration $configuration /p:CreateBootstrap=true $properties $extra_properties || exit $?
 fi
 
-bootstrapRoot="$artifacts_dir/bin/bootstrap"
-# export to make this available to `eng/common/build.sh`
-export artifacts_dir="$artifacts_dir/2"
+bootstrapRoot="$Stage1Dir/bin/bootstrap"
 
 if [ $host_type = "core" ]
 then
@@ -118,6 +117,8 @@ else
   echo "Unsupported hostType ($host_type)"
   exit 1
 fi
+
+mv $artifacts_dir $Stage1Dir
 
 # Ensure that debug bits fail fast, rather than hanging waiting for a debugger attach.
 export MSBUILDDONOTLAUNCHDEBUGGER=true

--- a/install-mono-prefix.sh
+++ b/install-mono-prefix.sh
@@ -5,7 +5,7 @@ if [ $# -lt 1 ]; then
        exit 1
 fi
 
-BOOTSTRAP_DIR_PREFIX="artifacts/2/bin/MSBuild.Bootstrap/"
+BOOTSTRAP_DIR_PREFIX="artifacts/bin/MSBuild.Bootstrap/"
 
 if [ -d "$BOOTSTRAP_DIR_PREFIX/Release-MONO" ]; then
     CONFIG=Release-MONO

--- a/mono/build/install.proj
+++ b/mono/build/install.proj
@@ -15,7 +15,7 @@
 
             <XBuildDir>$(MonoInstallPrefix)\lib\mono\xbuild</XBuildDir>
 
-            <MSBuildBinSrcDir>$(RepoRoot)artifacts\2\bin\MSBuild.Bootstrap\$(Configuration)\net472\</MSBuildBinSrcDir>
+            <MSBuildBinSrcDir>$(RepoRoot)artifacts\bin\MSBuild.Bootstrap\$(Configuration)\net472\</MSBuildBinSrcDir>
 
             <AllInstalledFiles_FileCanonical>$(MSBuildThisFileDirectory)\all_files.canon.txt</AllInstalledFiles_FileCanonical>
             <AllInstalledFiles_File>$(MSBuildThisFileDirectory)\all_files.new.txt</AllInstalledFiles_File>


### PR DESCRIPTION
.. essentially, to move the initial build to `stage1` and use
`artifacts/` as the final directory for the bootstrapped build, instead
of `artifacts/2/`.