### PR TITLE
Update the 3.0.100p9 versions

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-      <MicrosoftNetCompilersVersion>3.3.1-beta3-19421-04</MicrosoftNetCompilersVersion>
-      <CompilerToolsVersion>3.3.1-beta3-19421-04</CompilerToolsVersion>
+      <MicrosoftNetCompilersVersion>3.3.1-beta3-19423-01</MicrosoftNetCompilersVersion>
+      <CompilerToolsVersion>3.3.1-beta3-19423-01</CompilerToolsVersion>
       <NuGetPackageVersion>5.3.0-rtm.6192</NuGetPackageVersion>
       <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
       <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>

--- a/mono/build/DotNetBitsVersions.props
+++ b/mono/build/DotNetBitsVersions.props
@@ -1,12 +1,12 @@
 <Project>
     <PropertyGroup>
-        <MicrosoftNETSdkPackageVersion>3.0.100-preview9.19413.5</MicrosoftNETSdkPackageVersion>
+        <MicrosoftNETSdkPackageVersion>3.0.100-rc1.19453.1</MicrosoftNETSdkPackageVersion>
 
         <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
 
-        <MicrosoftNETSdkRazorPackageVersion>3.0.0-preview9.19422.6</MicrosoftNETSdkRazorPackageVersion>
+        <MicrosoftNETSdkRazorPackageVersion>3.0.0-preview9.19455.12</MicrosoftNETSdkRazorPackageVersion>
 
-        <MicrosoftNETSdkWebPackageVersion>3.0.100-preview9.19423.3</MicrosoftNETSdkWebPackageVersion>
+        <MicrosoftNETSdkWebPackageVersion>3.0.100-rc1.19455.5</MicrosoftNETSdkWebPackageVersion>
         <MicrosoftNETSdkPublishPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkPublishPackageVersion>
         <MicrosoftNETSdkWebProjectSystemPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkWebProjectSystemPackageVersion>
 


### PR DESCRIPTION
MicrosoftNetCompilersVersion: 3.3.1-beta3-19423-01
CompilerToolsVersion: 3.3.1-beta3-19423-01
MicrosoftNETSdkPackageVersion: 3.0.100-rc1.19453.1
MicrosoftNETSdkRazorPackageVersion: 3.0.0-preview9.19455.12
MicrosoftNETSdkWebPackageVersion: 3.0.100-rc1.19455.5

pulled from https://github.com/dotnet/toolset/blob/release/3.0.100-preview9/eng/Versions.props
at commit d0e97aa