### PR TITLE
[mono] Workaround for the assumption that `dotnet` is installed

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -340,8 +340,8 @@ function MSBuild {
 
     # Work around issues with Azure Artifacts credential provider
     # https://github.com/dotnet/arcade/issues/3932
-    if [[ "$ci" == true ]]; then
-      nuget locals http-cache -Clear
+    if [[ "$ci" == true && `which dotnet` ]]; then
+        dotnet nuget locals http-cache -c
     fi
 
     local toolset_dir="${_InitializeToolset%/*}"

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -341,7 +341,7 @@ function MSBuild {
     # Work around issues with Azure Artifacts credential provider
     # https://github.com/dotnet/arcade/issues/3932
     if [[ "$ci" == true ]]; then
-      dotnet nuget locals http-cache -c
+      nuget locals http-cache -Clear
     fi
 
     local toolset_dir="${_InitializeToolset%/*}"


### PR DESCRIPTION
We moved to building purely with mono, earlier and thus skip the dotnet
installation in the scripts. This breaks that. Fixing it up in-place for
now.

Commit 2: (Patch on behalf of Alexander Köplinger)
Also, fix the command line, as the `dotnet nuget` uses a different
command line syntax than the standalone `nuget` that mono bundles.

    `nuget locals http-cache -c` -> `nuget locals http-cache -Clear`