### PR TITLE
[mono] Fix msbuild regression in version string

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>16.3.0</VersionPrefix>
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <!-- DotNetFinalVersionKind>release</DotNetFinalVersionKind -->
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>


### PR DESCRIPTION
After the recent merge, a simple invocation of msbuild fails with:

```
MSBUILD : error MSB1025: An internal failure occurred while running MSBuild.
System.ArgumentOutOfRangeException: Index and length must refer to a location within the string.
Parameter name: length
  at System.String.Substring (System.Int32 startIndex, System.Int32 length) [0x00073] in /Users/radical/dev/mono/external/corefx/src/Common/src/CoreLib/System/String.Manipulation.cs:1626
  at Microsoft.Build.Evaluation.ProjectCollection.get_DisplayVersion () [0x00026] in /Users/radical/dev/msbuild/src/Build/Definition/ProjectCollection.cs:474
  at Microsoft.Build.CommandLine.MSBuildApp.DisplayCopyrightMessage () [0x0002d] in /Users/radical/dev/msbuild/src/MSBuild/XMake.cs:3647
  at Microsoft.Build.CommandLine.MSBuildApp.ProcessCommandLineSwitches (Microsoft.Build.CommandLine.CommandLineSwitches switchesFromAutoResponseFile, Microsoft.Build.CommandLine.CommandLineSwitches switchesNotFromAutoResponseFile, System.String& projectFile, System.String[]& targets, System.String& toolsVersion, System.Collections.Generic.Dictionary`2[System.String,System.String]& globalProperties, Microsoft.Build.Framework.ILogger[]& loggers, Microsoft.Build.Framework.LoggerVerbosity& verbosity, System.Collections.Generic.List`1[Microsoft.Build.CommandLine.DistributedLoggerRecord]& distributedLoggerRecords, System.Int32& cpuCount, System.Boolean& enableNodeReuse, System.IO.TextWriter& preprocessWriter, System.Boolean& detailedSummary, System.Collections.Generic.ISet`1[System.String]& warningsAsErrors, System.Collections.Generic.ISet`1[System.String]& warningsAsMessages, System.Boolean& enableRestore, System.Boolean& interactive, Microsoft.Build.Logging.ProfilerLogger& profilerLogger, System.Boolean& enableProfiler, System.Collections.Generic.Dictionary`2[System.String,System.String]& restoreProperties, System.Boolean& isolateProjects, System.Boolean& graphBuild, System.String[]& inputResultsCaches, System.String& outputResultsCache, System.Boolean recursing) [0x0002d] in /Users/radical/dev/msbuild/src/MSBuild/XMake.cs:2064
  at Microsoft.Build.CommandLine.MSBuildApp.Execute (System.String commandLine) [0x00418] in /Users/radical/dev/msbuild/src/MSBuild/XMake.cs:791
  at Microsoft.Build.CommandLine.MSBuildApp.Main () [0x0001c] in /Users/radical/dev/msbuild/src/MSBuild/XMake.cs:219 o]
```

The relevant code in `ProjectCollection`:
```
                      var fullInformationalVersion = typeof(Constants).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;

                      // use a truncated version with only 9 digits of SHA
                      s_assemblyDisplayVersion = fullInformationalVersion.Substring(startIndex: 0, length: fullInformationalVersion.IndexOf('+') + 10);
```

The `AssemblyInformationalVersionAttribute` is getting the value
`16.3.0`, instead of an expected longer string. Upstream builds have:

`[assembly:
System.Reflection.AssemblyInformationalVersionAttribute("16.3.0-dev-19468-01+e4b71d427dbc3aae09b7b922f769f8e633ee54ce")]`

.. for the msbuild assemblies, and mono's build previously had:

`[assembly:
System.Reflection.AssemblyInformationalVersionAttribute("16.3.0-ci-19468-01")]`

Mono's string is set like that because it has
`$(ContinuousIntegrationBuild)==true`, which arcade uses to build the
version suffix.

The recent merge added
`<DotNetFinalVersionKind>release</DotNetFinalVersionKind>` which makes
Arcade drop the "prerelease" suffixes, causing the version string to
become just `16.3.0`.

Since the code in `ProjectCollection` really expects to have a `SHA` in
the version string, this code just *happens* to work, for now and needs
to be fixed.