### PR TITLE
[2019-08] Update SDKs to track vs16.4 and `.NET Core 3.1 Dev`

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -32,7 +32,7 @@
     <PackageReference Update="System.Net.Http" Version="4.3.4" />
     <PackageReference Update="System.Reflection.Metadata" Version="1.6.0" />
     <PackageReference Update="System.Reflection.TypeExtensions" Version="4.1.0" />
-    <PackageReference Update="System.Resources.Extensions" Version="$(SystemResourcesExtensionsVersion)" />
+    <PackageReference Update="System.Resources.Extensions" Version="4.6.0" />
     <PackageReference Update="System.Resources.Writer" Version="4.0.0" />
     <PackageReference Update="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Update="System.Runtime.Loader" Version="4.0.0" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,9 +15,9 @@
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
       <Sha>4ccb010d3d0d0f805c2f2d645662643c5b181e25</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.1.100-preview1.19503.3">
+    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.0.100-rc2.19465.1">
       <Uri>https://github.com/aspnet/websdk</Uri>
-      <Sha>7ca44c4dbf83c00067054c4a9bd1f672bd2ba44e</Sha>
+      <Sha>002ea5ca7c699d925281abd8307556ec8eccb530</Sha>
     </Dependency>
     <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.19380.1">
       <Uri>https://github.com/mono/linker</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -31,10 +31,6 @@
       <Uri>https://github.com/dotnet/cli</Uri>
       <Sha>5a44f16c79b1d4f5bf0fb2500454347acdaa38aa</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers" Version="3.3.1-beta3-19426-02">
-      <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c82648d8964d1e683f92b7daa91beef2fdc5fb72</Sha>
-    </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.3.0-rtm.6192">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
       <Sha>bb60d6720d24890b8f3e071e70d27ea0f2bef57e</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,10 +6,4 @@
       <Sha>372f44450f51552a8cf725acf705dc477bd8391f</Sha>
     </Dependency>
   </ToolsetDependencies>
-  <ProductDependencies>
-    <Dependency Name="System.Resources.Extensions" Version="4.6.0-rc2.19458.3">
-      <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>173d70b99a5dbb3ff9298a6e2e9c7f7e7b56dd7c</Sha>
-    </Dependency>
-  </ProductDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,29 +7,29 @@
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="3.1.100-preview1.19463.2">
+    <Dependency Name="Microsoft.NET.Sdk" Version="3.1.100-preview1.19504.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>a19b734139ab62de631c31897b0ffc35f8462f3f</Sha>
+      <Sha>7def7a9c5adc9e4d52a4cf19eee2c3998e3f3b93</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="3.1.0-preview1.19470.1">
+    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="3.1.0-preview1.19502.3">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
-      <Sha>f283e4a7c0d47054c9a178ff0b29f00e68f307d3</Sha>
+      <Sha>4ccb010d3d0d0f805c2f2d645662643c5b181e25</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.0.100-rc2.19461.2">
+    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.1.100-preview1.19503.3">
       <Uri>https://github.com/aspnet/websdk</Uri>
-      <Sha>9471e9daf66b1e4f03d8b461c3ca0594f742923b</Sha>
+      <Sha>7ca44c4dbf83c00067054c4a9bd1f672bd2ba44e</Sha>
     </Dependency>
     <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.19380.1">
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>1127689f262d52ea8ff68ef03d706fa62b3b40a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-preview1.19467.7">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-preview1.19504.2">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>1e19b8c0d63fe23da7bdd9625ca51c6bd2d1bab2</Sha>
+      <Sha>50de4c0d1f33599adc6d71ae6d5b8783140c0b83</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-preview1.19467.5">
+    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-preview1.19504.3">
       <Uri>https://github.com/dotnet/cli</Uri>
-      <Sha>11fe23d96c69dad32ab5267d63e572778c5d6de5</Sha>
+      <Sha>5a44f16c79b1d4f5bf0fb2500454347acdaa38aa</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Net.Compilers" Version="3.3.1-beta3-19426-02">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,10 +34,6 @@
   <PropertyGroup>
     <DotNetCliVersion>3.0.100-preview6-012264</DotNetCliVersion>
   </PropertyGroup>
-  <!-- Product Dependencies -->
-  <PropertyGroup>
-    <SystemResourcesExtensionsVersion>4.6.0-rc2.19458.3</SystemResourcesExtensionsVersion>
-  </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,10 +15,10 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup>
-    <VersionPrefix>16.3.0</VersionPrefix>
-    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
+    <VersionPrefix>16.3.1</VersionPrefix>
+    <!-- <DotNetFinalVersionKind>release</DotNetFinalVersionKind> -->
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!-- Workaround for https://github.com/dotnet/roslyn/issues/35793 -->
     <SemanticVersioningV1>true</SemanticVersioningV1>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,7 +37,7 @@
     <MicrosoftNetCompilersVersion>3.3.1-beta4-19462-11</MicrosoftNetCompilersVersion>
     <MicrosoftNETSdkVersion>3.1.100-preview1.19504.1</MicrosoftNETSdkVersion>
     <MicrosoftNETSdkRazorVersion>3.1.0-preview1.19502.3</MicrosoftNETSdkRazorVersion>
-    <MicrosoftNETSdkWebVersion>3.1.100-preview1.19503.3</MicrosoftNETSdkWebVersion>
+    <MicrosoftNETSdkWebVersion>3.0.100-rc2.19465.1</MicrosoftNETSdkWebVersion>
     <NuGetBuildTasksVersion>5.3.0-rtm.6192</NuGetBuildTasksVersion>
     <ILLinkTasksVersion>0.1.6-prerelease.19380.1</ILLinkTasksVersion>
     <MicrosoftNETCoreAppVersion>3.1.0-preview1.19504.2</MicrosoftNETCoreAppVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>16.3.1</VersionPrefix>
-    <!-- <DotNetFinalVersionKind>release</DotNetFinalVersionKind> -->
+    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,13 +35,13 @@
   <PropertyGroup>
     <DotNetCliVersion>3.0.100-preview6-012264</DotNetCliVersion>
     <MicrosoftNetCompilersVersion>3.3.1-beta4-19462-11</MicrosoftNetCompilersVersion>
-    <MicrosoftNETSdkVersion>3.1.100-preview1.19463.2</MicrosoftNETSdkVersion>
-    <MicrosoftNETSdkRazorVersion>3.1.0-preview1.19470.1</MicrosoftNETSdkRazorVersion>
-    <MicrosoftNETSdkWebVersion>3.0.100-rc2.19461.2</MicrosoftNETSdkWebVersion>
+    <MicrosoftNETSdkVersion>3.1.100-preview1.19504.1</MicrosoftNETSdkVersion>
+    <MicrosoftNETSdkRazorVersion>3.1.0-preview1.19502.3</MicrosoftNETSdkRazorVersion>
+    <MicrosoftNETSdkWebVersion>3.1.100-preview1.19503.3</MicrosoftNETSdkWebVersion>
     <NuGetBuildTasksVersion>5.3.0-rtm.6192</NuGetBuildTasksVersion>
     <ILLinkTasksVersion>0.1.6-prerelease.19380.1</ILLinkTasksVersion>
-    <MicrosoftNETCoreAppVersion>3.1.0-preview1.19467.7</MicrosoftNETCoreAppVersion>
-    <MicrosoftDotNetCliRuntimeVersion>3.1.100-preview1.19467.5</MicrosoftDotNetCliRuntimeVersion>
+    <MicrosoftNETCoreAppVersion>3.1.0-preview1.19504.2</MicrosoftNETCoreAppVersion>
+    <MicrosoftDotNetCliRuntimeVersion>3.1.100-preview1.19504.3</MicrosoftDotNetCliRuntimeVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386

--- a/eng/common/templates/post-build/channels/netcore-dev-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-30.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-dev-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-30.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-dev-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-31.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-dev-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-31.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-dev-5.yml
+++ b/eng/common/templates/post-build/channels/netcore-dev-5.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -110,7 +110,7 @@ stages:
             /p:ChecksumsAzureAccountKey=$(InternalChecksumsBlobFeedKey)
             /p:InstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
             /p:InstallersAzureAccountKey=$(InternalInstallersBlobFeedKey)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-internal-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-internal-30.yml
@@ -110,7 +110,7 @@ stages:
             /p:ChecksumsAzureAccountKey=$(InternalChecksumsBlobFeedKey)
             /p:InstallersTargetStaticFeed=$(InternalInstallersBlobFeedUrl)
             /p:InstallersAzureAccountKey=$(InternalInstallersBlobFeedKey)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3-internal-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-release-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-30.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-release-30.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-30.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-release-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-31.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-release-31.yml
+++ b/eng/common/templates/post-build/channels/netcore-release-31.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/netcore-tools-latest.yml
+++ b/eng/common/templates/post-build/channels/netcore-tools-latest.yml
@@ -112,7 +112,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -77,7 +77,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
+            /p:PublishToAzureDevOpsNuGetFeeds=false
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'

--- a/eng/common/templates/post-build/channels/public-validation-release.yml
+++ b/eng/common/templates/post-build/channels/public-validation-release.yml
@@ -77,7 +77,7 @@ stages:
             /p:InstallersAzureAccountKey=$(dotnetcli-storage-key)
             /p:ChecksumsTargetStaticFeed=$(ChecksumsBlobFeedUrl)
             /p:ChecksumsAzureAccountKey=$(dotnetclichecksums-storage-key)
-            /p:PublishToAzureDevOpsNuGetFeeds=true
+            /p:PublishToAzureDevOpsNuGetFeeds=false #TODO: change this back to true once https://github.com/dotnet/arcade/issues/3942 is fixed
             /p:AzureDevOpsStaticShippingFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'
             /p:AzureDevOpsStaticShippingFeedKey='$(dn-bot-dnceng-artifact-feeds-rw)'
             /p:AzureDevOpsStaticTransportFeed='https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json'

--- a/mono/build/all_files.canon.txt
+++ b/mono/build/all_files.canon.txt
@@ -134,6 +134,8 @@ lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/build/netstandard2.0/S
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/buildMultiTargeting/Microsoft.NET.Sdk.Razor.props
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/buildMultiTargeting/Sdk.Razor.CurrentVersion.MultiTargeting.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/extensions/mvc-3-0/Microsoft.AspNetCore.Mvc.Razor.Extensions.dll
+lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/lib/netstandard2.0/_._
+lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/packageIcon.png
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/tasks/net46/Microsoft.NET.Sdk.Razor.Tasks.dll
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/tasks/net46/System.Collections.Immutable.dll
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/tasks/net46/System.Reflection.Metadata.dll
@@ -147,6 +149,8 @@ lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/Microsoft.A
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/Microsoft.AspNetCore.Components.Analyzers.dll
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/Microsoft.AspNetCore.Mvc.Analyzers.dll
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/Microsoft.AspNetCore.Mvc.Api.Analyzers.dll
+lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/Sdk/Sdk.AfterCommon.targets
+lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/Sdk/Sdk.BeforeCommon.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/Sdk/Sdk.props
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/Sdk/Sdk.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ComposeStore.targets
@@ -164,6 +168,7 @@ lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.NuGetO
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ObsoleteReferences.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.PackProjectTool.props
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.PackProjectTool.targets
+lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.PackStubs.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.PackTool.props
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.PackTool.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.PreserveCompilationContext.targets
@@ -189,6 +194,7 @@ lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.ta
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.SupportedTargetFrameworks.props
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets
+lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolutionStubs.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/tools/net472/Microsoft.DotNet.PlatformAbstractions.dll
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/tools/net472/Microsoft.Extensions.DependencyModel.dll
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/tools/net472/Microsoft.NET.Build.Tasks.dll

--- a/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj
+++ b/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj
@@ -13,9 +13,7 @@
         <MSBuildExtensionsPathOutputDirectory>$(DotNetOverlayDirectory)\ExtensionsPath</MSBuildExtensionsPathOutputDirectory>
         <MSBuildExtensionsPathToolsVersionOutputDirectory>$(DotNetOverlayDirectory)\ExtensionsPath-ToolsVersion</MSBuildExtensionsPathToolsVersionOutputDirectory>
 
-        <HostFxrUrl>$(CoreSetupRootUrl)$(HostFxrVersion)/$(DownloadedHostFxrInstallerFileName)$(CoreSetupBlobAccessTokenParam)</HostFxrUrl>
         <MSBuildSdkResolverOutDir>$(DotNetOverlayDirectory)\msbuild-bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver</MSBuildSdkResolverOutDir>
-        <RuntimeDepsInstallerUrl>$(CoreSetupRootUrl)$(MicrosoftNETCoreAppVersion)/$(DownloadedRuntimeDepsInstallerFileName)$(CoreSetupBlobAccessTokenParam)</RuntimeDepsInstallerUrl>
     </PropertyGroup>
 
     <Target Name="DeploySdksAndNuGets">

--- a/src/Build.UnitTests/BackEnd/BuildRequestEngine_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/BuildRequestEngine_Tests.cs
@@ -169,18 +169,12 @@ namespace Microsoft.Build.UnitTests.BackEnd
 
             public void RaiseRequestComplete(BuildRequestEntry entry)
             {
-                if (null != OnBuildRequestCompleted)
-                {
-                    OnBuildRequestCompleted(entry);
-                }
+                OnBuildRequestCompleted?.Invoke(entry);
             }
 
             public void RaiseRequestBlocked(BuildRequestEntry entry, int blockingId, string blockingTarget)
             {
-                if (null != OnBuildRequestBlocked)
-                {
-                    OnBuildRequestBlocked(entry, blockingId, blockingTarget, null);
-                }
+                OnBuildRequestBlocked?.Invoke(entry, blockingId, blockingTarget, null);
             }
 
             public void ContinueRequest()

--- a/src/Build.UnitTests/Evaluation/EvaluationLogging_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/EvaluationLogging_Tests.cs
@@ -125,28 +125,11 @@ namespace Microsoft.Build.UnitTests.Evaluation
             AssertLoggingEvents(
                 (project, firstEvaluationLogger) =>
                 {
-                    var allBuildEvents = firstEvaluationLogger.AllBuildEvents;
+                    var allBuildEvents = firstEvaluationLogger.AllBuildEvents.Where(be => be is ProjectEvaluationStartedEventArgs || be is ProjectEvaluationFinishedEventArgs).ToList();
 
-                    allBuildEvents.Count.ShouldBeGreaterThan(2);
-
-                    for (var i = 0; i < allBuildEvents.Count; i++)
-                    {
-                        var buildEvent = allBuildEvents[i];
-
-                        if (i == 0)
-                        {
-                            buildEvent.Message.ShouldStartWith("Evaluation started");
-                        }
-                        else if (i == allBuildEvents.Count - 1)
-                        {
-                            buildEvent.Message.ShouldStartWith("Evaluation finished");
-                        }
-                        else
-                        {
-                            buildEvent.Message.ShouldNotStartWith("Evaluation started");
-                            buildEvent.Message.ShouldNotStartWith("Evaluation finished");
-                        }
-                    }
+                    allBuildEvents.Count.ShouldBe(2);
+                    allBuildEvents[0].GetType().ShouldBe(typeof(ProjectEvaluationStartedEventArgs));
+                    allBuildEvents[1].GetType().ShouldBe(typeof(ProjectEvaluationFinishedEventArgs));
                 });
         }
 

--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -185,16 +185,16 @@ BuildEngine5.BuildProjectFilesInParallel(
         [Fact(Skip = "https://github.com/Microsoft/msbuild/issues/3876")]
         public void CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuiltAndOnContinueOnError()
         {
-            CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuilt2(addContinueOnError: true);
+            CacheEnforcementImpl(addContinueOnError: true);
         }
 
         [Fact]
         public void CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuiltWithoutContinueOnError()
         {
-            CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuilt2(addContinueOnError: false);
+            CacheEnforcementImpl(addContinueOnError: false);
         }
 
-        private void CacheEnforcementShouldFailWhenReferenceWasNotPreviouslyBuilt2(bool addContinueOnError)
+        private void CacheEnforcementImpl(bool addContinueOnError)
         {
             AssertBuild(
                 new[] {"BuildDeclaredReference"},
@@ -206,6 +206,14 @@ BuildEngine5.BuildProjectFilesInParallel(
 
                     logger.Errors.First()
                         .Message.ShouldStartWith("MSB4252:");
+
+                    logger.Errors.First().BuildEventContext.ShouldNotBe(BuildEventContext.Invalid);
+
+                    logger.Errors.First().BuildEventContext.NodeId.ShouldNotBe(BuildEventContext.InvalidNodeId);
+                    logger.Errors.First().BuildEventContext.ProjectInstanceId.ShouldNotBe(BuildEventContext.InvalidProjectInstanceId);
+                    logger.Errors.First().BuildEventContext.ProjectContextId.ShouldNotBe(BuildEventContext.InvalidProjectContextId);
+                    logger.Errors.First().BuildEventContext.TargetId.ShouldNotBe(BuildEventContext.InvalidTargetId);
+                    logger.Errors.First().BuildEventContext.TaskId.ShouldNotBe(BuildEventContext.InvalidTaskId);
                 },
                 addContinueOnError: addContinueOnError);
         }

--- a/src/Build.UnitTests/Graph/ResultCacheBasedBuilds_Tests.cs
+++ b/src/Build.UnitTests/Graph/ResultCacheBasedBuilds_Tests.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.Build.UnitTests;
 using Shouldly;
@@ -392,6 +393,12 @@ namespace Microsoft.Build.Experimental.Graph.UnitTests
             results["1"].Result.OverallResult.ShouldBe(BuildResultCode.Failure);
             results["1"].Logger.ErrorCount.ShouldBe(1);
             results["1"].Logger.Errors.First().Message.ShouldContain("MSB4252");
+
+            results["1"].Logger.Errors.First().BuildEventContext.NodeId.ShouldNotBe(BuildEventContext.InvalidNodeId);
+            results["1"].Logger.Errors.First().BuildEventContext.ProjectInstanceId.ShouldNotBe(BuildEventContext.InvalidProjectInstanceId);
+            results["1"].Logger.Errors.First().BuildEventContext.ProjectContextId.ShouldNotBe(BuildEventContext.InvalidProjectContextId);
+            results["1"].Logger.Errors.First().BuildEventContext.TargetId.ShouldNotBe(BuildEventContext.InvalidTargetId);
+            results["1"].Logger.Errors.First().BuildEventContext.TaskId.ShouldNotBe(BuildEventContext.InvalidTaskId);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/Logging/LoggingService.cs
+++ b/src/Build/BackEnd/Components/Logging/LoggingService.cs
@@ -1502,12 +1502,7 @@ namespace Microsoft.Build.BackEnd.Logging
         /// <param name="ex">Exception to raise to event handlers</param>
         private void RaiseLoggingExceptionEvent(Exception ex)
         {
-            LoggingExceptionDelegate loggingException = OnLoggingThreadException;
-
-            if (loggingException != null)
-            {
-                loggingException(ex);
-            }
+            OnLoggingThreadException?.Invoke(ex);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/RequestBuilder.cs
@@ -1000,12 +1000,7 @@ namespace Microsoft.Build.BackEnd
         /// <param name="requests">The requests to be fulfilled.</param>
         private void RaiseOnNewBuildRequests(FullyQualifiedBuildRequest[] requests)
         {
-            NewBuildRequestsDelegate newRequestDelegate = OnNewBuildRequests;
-
-            if (null != newRequestDelegate)
-            {
-                newRequestDelegate(_requestEntry, requests);
-            }
+            OnNewBuildRequests?.Invoke(_requestEntry, requests);
         }
 
         /// <summary>
@@ -1013,12 +1008,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void RaiseBuildRequestCompleted(BuildRequestEntry entryToComplete)
         {
-            BuildRequestCompletedDelegate completeRequestDelegate = OnBuildRequestCompleted;
-
-            if (null != completeRequestDelegate)
-            {
-                completeRequestDelegate(entryToComplete);
-            }
+            OnBuildRequestCompleted?.Invoke(entryToComplete);
         }
 
         /// <summary>
@@ -1026,12 +1016,7 @@ namespace Microsoft.Build.BackEnd
         /// </summary>
         private void RaiseOnBlockedRequest(int blockingGlobalRequestId, string blockingTarget, BuildResult partialBuildResult = null)
         {
-            BuildRequestBlockedDelegate blockedRequestDelegate = OnBuildRequestBlocked;
-
-            if (null != blockedRequestDelegate)
-            {
-                blockedRequestDelegate(_requestEntry, blockingGlobalRequestId, blockingTarget, partialBuildResult);
-            }
+            OnBuildRequestBlocked?.Invoke(_requestEntry, blockingGlobalRequestId, blockingTarget, partialBuildResult);
         }
 
         /// <summary>

--- a/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
+++ b/src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs
@@ -929,6 +929,16 @@ namespace Microsoft.Build.BackEnd
                         {
                             overallSuccess = false;
                         }
+
+                        if (!string.IsNullOrEmpty(results[i].SchedulerInducedError))
+                        {
+                            LoggingContext.LogErrorFromText(
+                                subcategoryResourceName: null,
+                                errorCode: null,
+                                helpKeyword: null,
+                                file: new BuildEventFileInfo(ProjectFileOfTaskNode, LineNumberOfTaskNode, ColumnNumberOfTaskNode),
+                                message: results[i].SchedulerInducedError);
+                        }
                     }
 
                     ErrorUtilities.VerifyThrow(results.Length == projectFileNames.Length || overallSuccess == false, "The number of results returned {0} cannot be less than the number of project files {1} unless one of the results indicated failure.", results.Length, projectFileNames.Length);

--- a/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
+++ b/src/Build/BackEnd/Components/Scheduler/Scheduler.cs
@@ -1832,21 +1832,14 @@ namespace Microsoft.Build.BackEnd
                     : string.Join(";", request.Targets));
 
             // Issue a failed build result to have the msbuild task marked as failed and thus stop the build
-            BuildResult result = new BuildResult(request, new InvalidOperationException(errorMessage));
+            BuildResult result = new BuildResult(request);
             result.SetOverallResult(false);
+
+            // Log an error to have something useful displayed to the user and to avoid having a failed build with 0 errors
+            result.SchedulerInducedError = errorMessage;
 
             var response = GetResponseForResult(nodeForResults, request, result);
             responses.Add(response);
-
-            // Log an error to have something displayed to the user and to avoid having a failed build with 0 errors
-            // todo Search if there's a way to have the error automagically logged in response to the failed build result
-            _componentHost.LoggingService.LogErrorFromText(
-                NewBuildEventContext(),
-                null,
-                null,
-                null,
-                new BuildEventFileInfo(requestConfig.ProjectFullPath),
-                errorMessage);
 
             return false;
 

--- a/src/Build/BackEnd/Shared/BuildResult.cs
+++ b/src/Build/BackEnd/Shared/BuildResult.cs
@@ -114,6 +114,8 @@ namespace Microsoft.Build.Execution
         /// </summary>
         private ProjectInstance _projectStateAfterBuild;
 
+        private string _schedulerInducedError;
+
         /// <summary>
         /// Constructor for serialization.
         /// </summary>
@@ -471,6 +473,16 @@ namespace Microsoft.Build.Execution
         }
 
         /// <summary>
+        /// Container used to transport errors from the scheduler (issued while computing a build result)
+        /// to the TaskHost that has the proper logging context (project id, target id, task id, file location)
+        /// </summary>
+        internal string SchedulerInducedError
+        {
+            get => _schedulerInducedError;
+            set => _schedulerInducedError = value;
+        }
+
+        /// <summary>
         /// Indexer which sets or returns results for the specified target
         /// </summary>
         /// <param name="target">The target</param>
@@ -564,6 +576,7 @@ namespace Microsoft.Build.Execution
             translator.Translate(ref _baseOverallResult);
             translator.Translate(ref _projectStateAfterBuild, ProjectInstance.FactoryForDeserialization);
             translator.Translate(ref _savedCurrentDirectory);
+            translator.Translate(ref _schedulerInducedError);
             translator.TranslateDictionary(ref _savedEnvironmentVariables, StringComparer.OrdinalIgnoreCase);
         }
 

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -3686,7 +3686,7 @@ namespace Microsoft.Build.Evaluation
                         {
                             if (TryGetArg(args, out string arg0))
                             {
-                                returnVal = string.Copy(arg0);
+                                returnVal = arg0;
                                 return true;
                             }
                         }

--- a/src/Build/Logging/FileLogger.cs
+++ b/src/Build/Logging/FileLogger.cs
@@ -81,6 +81,11 @@ namespace Microsoft.Build.Logging
             // want to make decisions based on our verbosity, so we do this last.
             base.Initialize(eventSource, nodeCount);
 
+            if (!SkipProjectStartedText && Verbosity >= LoggerVerbosity.Normal)
+            {
+                eventSource.BuildStarted += (obj, args) => WriteHandler(ResourceUtilities.FormatResourceStringStripCodeAndKeyword("LogLoggerVerbosity", Verbosity));
+            }
+
             try
             {
                 string logDirectory = null;

--- a/src/Build/Resources/Strings.resx
+++ b/src/Build/Resources/Strings.resx
@@ -1795,6 +1795,12 @@ Utilization:          {0} Average Utilization: {1:###.0}</value>
       LOCALIZATION: {0} and {1} are file paths
     </comment>
   </data>
+  <data name="LogLoggerVerbosity" xml:space="preserve">
+    <value>Logging verbosity is set to: {0}.</value>
+    <comment>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </comment>
+  </data>
   <!--
         The engine message bucket is: MSB4001 - MSB4999
 

--- a/src/Build/Resources/xlf/Strings.cs.xlf
+++ b/src/Build/Resources/xlf/Strings.cs.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: Následující vstupní soubory mezipaměti pro výsledky neexistují: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Metaprojekt {0} byl vygenerován.</target>

--- a/src/Build/Resources/xlf/Strings.de.xlf
+++ b/src/Build/Resources/xlf/Strings.de.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: Die folgenden Cachedateien für Eingabeergebnisse sind nicht vorhanden: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="needs-review-translation">Die Protokollierungsausführlichkeitsstufe ist gesetzt auf: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Das Metaprojekt "{0}" wurde generiert.</target>

--- a/src/Build/Resources/xlf/Strings.en.xlf
+++ b/src/Build/Resources/xlf/Strings.en.xlf
@@ -82,6 +82,13 @@
         <target state="new">MSB4255: The following input result cache files do not exist: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="new">Metaproject "{0}" generated.</target>

--- a/src/Build/Resources/xlf/Strings.es.xlf
+++ b/src/Build/Resources/xlf/Strings.es.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: Los siguientes archivos de caché de resultados de entrada no existen: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Se generó el metaproyecto "{0}".</target>

--- a/src/Build/Resources/xlf/Strings.fr.xlf
+++ b/src/Build/Resources/xlf/Strings.fr.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: Les fichiers cache des résultats d'entrée suivants n'existent pas : "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Le métaprojet "{0}" a été généré.</target>

--- a/src/Build/Resources/xlf/Strings.it.xlf
+++ b/src/Build/Resources/xlf/Strings.it.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: i file della cache dei risultati di input seguenti non esistono: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Il metaprogetto "{0}" è stato generato.</target>

--- a/src/Build/Resources/xlf/Strings.ja.xlf
+++ b/src/Build/Resources/xlf/Strings.ja.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: 以下の入力結果キャッシュ ファイルが存在しません: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">メタプロジェクト "{0}" が生成されました。</target>

--- a/src/Build/Resources/xlf/Strings.ko.xlf
+++ b/src/Build/Resources/xlf/Strings.ko.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: 다음 입력 결과 캐시 파일이 존재하지 않습니다. "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">메타프로젝트 "{0}"이(가) 생성되었습니다.</target>

--- a/src/Build/Resources/xlf/Strings.pl.xlf
+++ b/src/Build/Resources/xlf/Strings.pl.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: Następujące pliki wejściowej pamięci podręcznej wyników nie istnieją: „{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Wygenerowano metaprojekt „{0}”.</target>

--- a/src/Build/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Build/Resources/xlf/Strings.pt-BR.xlf
@@ -81,6 +81,13 @@
         <target state="translated">MSB4255: os arquivos de cache do resultado de entrada a seguir não existem: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Metaprojeto "{0}" gerado.</target>

--- a/src/Build/Resources/xlf/Strings.ru.xlf
+++ b/src/Build/Resources/xlf/Strings.ru.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: следующие входные файлы кэша результатов не существуют: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">Создан метапроект "{0}".</target>

--- a/src/Build/Resources/xlf/Strings.tr.xlf
+++ b/src/Build/Resources/xlf/Strings.tr.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: Şu giriş sonucu önbellek dosyaları mevcut değil: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">"{0}" meta projesi oluşturuldu.</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hans.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: 以下输入结果缓存文件不存在:“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">已生成元项目“{0}”。</target>

--- a/src/Build/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Build/Resources/xlf/Strings.zh-Hant.xlf
@@ -82,6 +82,13 @@
         <target state="translated">MSB4255: 下列輸入結果快取檔案不存在: "{0}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogLoggerVerbosity">
+        <source>Logging verbosity is set to: {0}.</source>
+        <target state="new">Logging verbosity is set to: {0}.</target>
+        <note>
+      LOCALIZATION: {0} is an enum value of LoggerVerbosity.
+    </note>
+      </trans-unit>
       <trans-unit id="MetaprojectGenerated">
         <source>Metaproject "{0}" generated.</source>
         <target state="translated">已產生中繼專案 "{0}"。</target>

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -608,7 +608,8 @@ namespace Microsoft.Build.CommandLine
                     // is a better way.
                     // Only display the message if /m isn't provided
                     if (cpuCount == 1 && FileUtilities.IsSolutionFilename(projectFile) && verbosity > LoggerVerbosity.Minimal
-                        && switchesNotFromAutoResponseFile[CommandLineSwitches.ParameterizedSwitch.MaxCPUCount].Length == 0)
+                        && switchesNotFromAutoResponseFile[CommandLineSwitches.ParameterizedSwitch.MaxCPUCount].Length == 0
+                        && switchesFromAutoResponseFile[CommandLineSwitches.ParameterizedSwitch.MaxCPUCount].Length == 0)
                     {
                         Console.WriteLine(ResourceUtilities.GetResourceString("PossiblyOmittedMaxCPUSwitch"));
                     }

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -606,7 +606,9 @@ namespace Microsoft.Build.CommandLine
                     // Unfortunately /m isn't the default, and we are not yet brave enough to make it the default.
                     // However we want to give a hint to anyone who is building single proc without realizing it that there
                     // is a better way.
-                    if (cpuCount == 1 && FileUtilities.IsSolutionFilename(projectFile) && verbosity > LoggerVerbosity.Minimal)
+                    // Only display the message if /m isn't provided
+                    if (cpuCount == 1 && FileUtilities.IsSolutionFilename(projectFile) && verbosity > LoggerVerbosity.Minimal
+                        && switchesNotFromAutoResponseFile[CommandLineSwitches.ParameterizedSwitch.MaxCPUCount].Length == 0)
                     {
                         Console.WriteLine(ResourceUtilities.GetResourceString("PossiblyOmittedMaxCPUSwitch"));
                     }
@@ -3314,7 +3316,7 @@ namespace Microsoft.Build.CommandLine
                 LoggerDescription centralLoggerDescription =
                     ParseLoggingParameter((string)loggerSpec[0], unquotedParameter, verbosity);
 
-                if(!CreateAndConfigureLogger(centralLoggerDescription, verbosity, unquotedParameter, out ILogger centralLogger))
+                if (!CreateAndConfigureLogger(centralLoggerDescription, verbosity, unquotedParameter, out ILogger centralLogger))
                 {
                     continue;
                 }

--- a/src/MSBuild/app.amd64.config
+++ b/src/MSBuild/app.amd64.config
@@ -10,6 +10,7 @@
       <DisableFXClosureWalk enabled="true" />
       <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
+      <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/MSBuild/app.config
+++ b/src/MSBuild/app.config
@@ -10,6 +10,7 @@
       <DisableFXClosureWalk enabled="true" />
       <DeferFXClosureWalk enabled="true" />
       <generatePublisherEvidence enabled="false" />
+      <AppContextSwitchOverrides value="Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
           <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/Shared/UnitTests/App.config
+++ b/src/Shared/UnitTests/App.config
@@ -9,7 +9,7 @@
   <runtime>
     <DisableFXClosureWalk enabled="true" />
     <generatePublisherEvidence enabled="false" />
-    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false" />
+    <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.Security.Cryptography.UseLegacyFipsThrow=false" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/Shared/UnitTests/ObjectModelHelpers.cs
+++ b/src/Shared/UnitTests/ObjectModelHelpers.cs
@@ -442,12 +442,10 @@ namespace Microsoft.Build.UnitTests
             if (expected == null)
             {
                 Assert.Null(actual); // "Expected a null array"
-            }
-            else
-            {
-                Assert.NotNull(actual); // "Result should be non-null."
+                return;
             }
 
+            Assert.NotNull(actual); // "Result should be non-null."
             Assert.Equal(expected.Length, actual.Length); // "Expected array length of <" + expected.Length + "> but was <" + actual.Length + ">.");
 
             // Now that we've verified they're both non-null and of the same length, compare each item in the array.

--- a/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
+++ b/src/Tasks.UnitTests/CreateCSharpManifestResourceName_Tests.cs
@@ -417,6 +417,47 @@ namespace Microsoft.Build.UnitTests
         }
 
         /// <summary>
+        /// Opt into DependentUpon convention but don't expect it to be used for this file.
+        /// </summary>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DependentUponConvention_DoesNotApplyToNonResx(bool explicitlySpecifyType)
+        {
+            using (var env = TestEnvironment.Create())
+            {
+                var csFile = env.CreateFile("SR1.cs", "namespace MyStuff.Namespace { class Class { } }");
+                const string ResourceFileName = "SR1.txt";
+                var resourceFile = env.CreateFile(ResourceFileName, "");
+
+                // Default resource naming is based on the item include, so use a relative
+                // path here instead of a full path.
+                env.SetCurrentDirectory(Path.GetDirectoryName(resourceFile.Path));
+                ITaskItem i = new TaskItem(ResourceFileName);
+                i.SetMetadata("BuildAction", "EmbeddedResource");
+                if (explicitlySpecifyType)
+                {
+                    i.SetMetadata("Type", "Non-Resx");
+                }
+                // Don't set DependentUpon so it goes by convention
+
+                CreateCSharpManifestResourceName t = new CreateCSharpManifestResourceName
+                {
+                    BuildEngine = new MockEngine(_testOutput),
+                    UseDependentUponConvention = true,
+                    ResourceFiles = new ITaskItem[] { i }
+                };
+
+                t.Execute().ShouldBeTrue("Expected the task to succeed.");
+
+                t.ManifestResourceNames.ShouldHaveSingleItem();
+
+                t.ManifestResourceNames[0].ItemSpec.ShouldBe(ResourceFileName, "Expecting to find the namespace & class name from SR1.cs");
+            }
+        }
+
+
+        /// <summary>
         /// Opt into DependentUpon convention and load the expected file properly when the file is in a subfolder.
         /// </summary>
         [Fact]

--- a/src/Tasks/CreateManifestResourceName.cs
+++ b/src/Tasks/CreateManifestResourceName.cs
@@ -146,8 +146,20 @@ namespace Microsoft.Build.Tasks
                     string fileName = resourceFile.ItemSpec;
                     string dependentUpon = resourceFile.GetMetadata(ItemMetadataNames.dependentUpon);
 
-                    // If opted into convention and no DependentUpon metadata, reference "<filename>.cs" if it exists.
-                    if (UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))
+                    string fileType = resourceFile.GetMetadata("Type");
+
+                    // If it has "type" metadata and the value is "Resx"
+                    // This value can be specified by the user, if not it will have been automatically assigned by the SplitResourcesByCulture target.
+                    bool isResxFile = (!string.IsNullOrEmpty(fileType) && fileType == "Resx");
+
+                    // If not, fall back onto the extension.
+                    if (string.IsNullOrEmpty(fileType))
+                    {
+                        isResxFile = Path.GetExtension(fileName) == ".resx";
+                    }
+
+                    // If opted into convention and no DependentUpon metadata and is a resx file, reference "<filename>.cs" if it exists.
+                    if (isResxFile && UseDependentUponConvention && string.IsNullOrEmpty(dependentUpon))
                     {
                         string conventionDependentUpon = Path.ChangeExtension(Path.GetFileName(fileName), SourceFileExtension);
 


### PR DESCRIPTION
- Merges upstream `vs16.4` branch
- Updates SDKs from maestro's `.NET Core 3.1 Dev`