### PR TITLE
[mono] Update SDK+roslyn versions to track `release/3.1.1xx`

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-      <MicrosoftNetCompilersVersion>3.3.1-beta4-19462-11</MicrosoftNetCompilersVersion>
-      <CompilerToolsVersion>3.3.1-beta4-19462-11</CompilerToolsVersion>
+      <MicrosoftNetCompilersVersion>3.4.0-beta2-19477-01</MicrosoftNetCompilersVersion>
+      <CompilerToolsVersion>$(MicrosoftNetCompilersVersion)</CompilerToolsVersion>
       <NuGetPackageVersion>5.3.0-rtm.6192</NuGetPackageVersion>
       <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
       <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,33 +7,33 @@
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="3.1.100-preview1.19504.1">
+    <Dependency Name="Microsoft.NET.Sdk" Version="3.1.100-preview1.19506.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>7def7a9c5adc9e4d52a4cf19eee2c3998e3f3b93</Sha>
+      <Sha>357126710492d620198a60ee340ebeca9070f133</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="3.1.0-preview1.19502.3">
+    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="3.1.0-preview1.19506.2">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
-      <Sha>4ccb010d3d0d0f805c2f2d645662643c5b181e25</Sha>
+      <Sha>96fa41506a0f7b234edeb221a366540de442292d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.0.100-rc2.19465.1">
+    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.1.100-preview1.19506.3">
       <Uri>https://github.com/aspnet/websdk</Uri>
-      <Sha>002ea5ca7c699d925281abd8307556ec8eccb530</Sha>
+      <Sha>c0a267ce79d0f14b8c700b9bdeff12b9ad672c75</Sha>
     </Dependency>
     <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.19380.1">
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>1127689f262d52ea8ff68ef03d706fa62b3b40a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-preview1.19504.2">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-preview1.19506.1">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>50de4c0d1f33599adc6d71ae6d5b8783140c0b83</Sha>
+      <Sha>bbf5542781136f9f3a1f30b010cb782e775d54c7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-preview1.19504.3">
+    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-preview1.19506.9">
       <Uri>https://github.com/dotnet/cli</Uri>
-      <Sha>5a44f16c79b1d4f5bf0fb2500454347acdaa38aa</Sha>
+      <Sha>d8f1eacf0615884bfbc1c4b1f6d6a3690b35bb65</Sha>
     </Dependency>
-    <Dependency Name="NuGet.Build.Tasks" Version="5.3.0-rtm.6192">
+    <Dependency Name="NuGet.Build.Tasks" Version="5.3.0-rtm.6251">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
-      <Sha>bb60d6720d24890b8f3e071e70d27ea0f2bef57e</Sha>
+      <Sha>b75150f2f4127a77a166c9552845e86fb24a3282</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -34,14 +34,14 @@
   <!-- Toolset Dependencies -->
   <PropertyGroup>
     <DotNetCliVersion>3.0.100-preview6-012264</DotNetCliVersion>
-    <MicrosoftNetCompilersVersion>3.3.1-beta4-19462-11</MicrosoftNetCompilersVersion>
-    <MicrosoftNETSdkVersion>3.1.100-preview1.19504.1</MicrosoftNETSdkVersion>
-    <MicrosoftNETSdkRazorVersion>3.1.0-preview1.19502.3</MicrosoftNETSdkRazorVersion>
-    <MicrosoftNETSdkWebVersion>3.0.100-rc2.19465.1</MicrosoftNETSdkWebVersion>
+    <MicrosoftNetCompilersVersion>3.4.0-beta2-19477-01</MicrosoftNetCompilersVersion>
+    <MicrosoftNETSdkVersion>3.1.100-preview1.19506.1</MicrosoftNETSdkVersion>
+    <MicrosoftNETSdkRazorVersion>3.1.0-preview1.19506.2</MicrosoftNETSdkRazorVersion>
+    <MicrosoftNETSdkWebVersion>3.1.100-preview1.19506.3</MicrosoftNETSdkWebVersion>
     <NuGetBuildTasksVersion>5.3.0-rtm.6192</NuGetBuildTasksVersion>
     <ILLinkTasksVersion>0.1.6-prerelease.19380.1</ILLinkTasksVersion>
-    <MicrosoftNETCoreAppVersion>3.1.0-preview1.19504.2</MicrosoftNETCoreAppVersion>
-    <MicrosoftDotNetCliRuntimeVersion>3.1.100-preview1.19504.3</MicrosoftDotNetCliRuntimeVersion>
+    <MicrosoftNETCoreAppVersion>3.1.0-preview1.19506.1</MicrosoftNETCoreAppVersion>
+    <MicrosoftDotNetCliRuntimeVersion>3.1.100-preview1.19506.9</MicrosoftDotNetCliRuntimeVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386


### PR DESCRIPTION
```
Microsoft.NET.Sdk:                      3.1.100-preview1.19506.1
Microsoft.NET.Sdk.Web:                  3.1.100-preview1.19506.3
Microsoft.NET.Sdk.Razor:                3.1.0-preview1.19506.2

Microsoft.NETCore.App:                  3.1.0-preview1.19506.1
Microsoft.DotNet.Cli.Runtime:           3.1.100-preview1.19506.9

NuGet.Build.Tasks:                      5.3.0-rtm.6251

Roslyn:                                 3.4.0-beta2-19477-01
```

Based on `dotnet/toolset` `release/3.1.1xx` branch HEAD
(e9c6794f1f124e273571237eb72a949ee5c950c6):

https://github.com/dotnet/toolset/blob/e9c6794f1f124e273571237eb72a949ee5c950c6/eng/Versions.props#L36