### PR TITLE
[mono] Update Roslyn to match `dotnet/toolset` `release/3.1.1xx`

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-      <MicrosoftNetCompilersVersion>3.4.0-beta2-19477-01</MicrosoftNetCompilersVersion>
+      <MicrosoftNetCompilersVersion>3.4.0-beta3-19521-01</MicrosoftNetCompilersVersion>
       <CompilerToolsVersion>$(MicrosoftNetCompilersVersion)</CompilerToolsVersion>
       <NuGetPackageVersion>5.3.0-rtm.6192</NuGetPackageVersion>
       <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>


### PR DESCRIPTION
.. from commit: 172f26ddc1dc3c96f14bfcba8519544d30d6d3e2

Version: `3.4.0-beta3-19521-01`
Version from: https://github.com/dotnet/toolset/blob/172f26ddc1dc3c96f14bfcba8519544d30d6d3e2/eng/Versions.props#L36