### PR TITLE
[mono] Update SDKs to track `release/3.1.1xx`

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
       <MicrosoftNetCompilersVersion>3.4.0-beta3-19521-01</MicrosoftNetCompilersVersion>
       <CompilerToolsVersion>$(MicrosoftNetCompilersVersion)</CompilerToolsVersion>
-      <NuGetPackageVersion>5.3.0-rtm.6251</NuGetPackageVersion>
+      <NuGetPackageVersion>5.4.0-preview.3.6271</NuGetPackageVersion>
       <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
       <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>
       <NuGetProtocolVersion Condition="'$(NuGetProtocolVersion)' == ''">$(NuGetPackageVersion)</NuGetProtocolVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,25 +15,25 @@
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
       <Sha>c034007a2d17e04decd619d875307392656ae94f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.1.100-preview2.19521.2">
+    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.1.100-preview2.19522.3">
       <Uri>https://github.com/aspnet/websdk</Uri>
-      <Sha>b79adac75df36d7e1adcacb43e09cea24b765aca</Sha>
+      <Sha>fc43342cc5049b407849588e0d6e58793e8837d0</Sha>
     </Dependency>
     <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.19380.1">
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>1127689f262d52ea8ff68ef03d706fa62b3b40a1</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-preview2.19521.15">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.1.0-preview2.19522.9">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>f830769364b45286b638a57176d4a7997dbc5237</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-preview2.19521.2">
+    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-preview2.19522.5">
       <Uri>https://github.com/dotnet/cli</Uri>
-      <Sha>08f2a44fd1a2ca4363b656c730123370f4f91942</Sha>
+      <Sha>fec43d22c486a8e312811cc769e320a62d86c552</Sha>
     </Dependency>
-    <Dependency Name="NuGet.Build.Tasks" Version="5.3.0-rtm.6251">
+    <Dependency Name="NuGet.Build.Tasks" Version="5.4.0-preview.3.6271">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
-      <Sha>b75150f2f4127a77a166c9552845e86fb24a3282</Sha>
+      <Sha>c1f6915918b82c096bbd666bd9c18528f1f70630</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -37,11 +37,11 @@
     <MicrosoftNetCompilersVersion>3.4.0-beta3-19521-01</MicrosoftNetCompilersVersion>
     <MicrosoftNETSdkVersion>3.1.100-preview1.19506.1</MicrosoftNETSdkVersion>
     <MicrosoftNETSdkRazorVersion>3.1.0-preview2.19518.7</MicrosoftNETSdkRazorVersion>
-    <MicrosoftNETSdkWebVersion>3.1.100-preview2.19521.2</MicrosoftNETSdkWebVersion>
-    <NuGetBuildTasksVersion>5.3.0-rtm.6251</NuGetBuildTasksVersion>
+    <MicrosoftNETSdkWebVersion>3.1.100-preview2.19522.3</MicrosoftNETSdkWebVersion>
+    <NuGetBuildTasksVersion>5.4.0-preview.3.6271</NuGetBuildTasksVersion>
     <ILLinkTasksVersion>0.1.6-prerelease.19380.1</ILLinkTasksVersion>
-    <MicrosoftNETCoreAppVersion>3.1.0-preview2.19521.15</MicrosoftNETCoreAppVersion>
-    <MicrosoftDotNetCliRuntimeVersion>3.1.100-preview2.19521.2</MicrosoftDotNetCliRuntimeVersion>
+    <MicrosoftNETCoreAppVersion>3.1.0-preview2.19522.9</MicrosoftNETCoreAppVersion>
+    <MicrosoftDotNetCliRuntimeVersion>3.1.100-preview2.19522.5</MicrosoftDotNetCliRuntimeVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386

--- a/mono/build/all_files.canon.txt
+++ b/mono/build/all_files.canon.txt
@@ -95,6 +95,7 @@ lib/mono/msbuild/Current/bin/Sdks/Microsoft.Docker.Sdk/Sdk/Sdk.props
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.Docker.Sdk/Sdk/Sdk.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Publish/Sdk/Sdk.props
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Publish/Sdk/Sdk.targets
+lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Publish/packageIcon.png
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Publish/targets/ComputeTargets/Microsoft.NET.Sdk.Publish.ComputeFiles.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Publish/targets/CopyTargets/Microsoft.NET.Sdk.Publish.CopyFiles.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Publish/targets/DotNetCLIToolTargets/Microsoft.NET.Sdk.DotNetCLITool.targets
@@ -141,6 +142,7 @@ lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/tasks/net46/System.Col
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Razor/tasks/net46/System.Reflection.Metadata.dll
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web.ProjectSystem/Sdk/Sdk.props
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web.ProjectSystem/Sdk/Sdk.targets
+lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web.ProjectSystem/packageIcon.png
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web.ProjectSystem/targets/Microsoft.NET.Sdk.Web.ProjectSystem.props
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web.ProjectSystem/targets/Microsoft.NET.Sdk.Web.ProjectSystem.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web/Sdk/Sdk.props
@@ -149,6 +151,7 @@ lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/Microsoft.A
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/Microsoft.AspNetCore.Components.Analyzers.dll
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/Microsoft.AspNetCore.Mvc.Analyzers.dll
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/Microsoft.AspNetCore.Mvc.Api.Analyzers.dll
+lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk.Web/packageIcon.png
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/Sdk/Sdk.AfterCommon.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/Sdk/Sdk.BeforeCommon.targets
 lib/mono/msbuild/Current/bin/Sdks/Microsoft.NET.Sdk/Sdk/Sdk.props

--- a/mono/build/all_files.canon.txt
+++ b/mono/build/all_files.canon.txt
@@ -82,6 +82,7 @@ lib/mono/msbuild/Current/bin/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/ru
 lib/mono/msbuild/Current/bin/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/tr/Microsoft.DotNet.MSBuildSdkResolver.resources.dll
 lib/mono/msbuild/Current/bin/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/zh-Hans/Microsoft.DotNet.MSBuildSdkResolver.resources.dll
 lib/mono/msbuild/Current/bin/SdkResolvers/Microsoft.DotNet.MSBuildSdkResolver/zh-Hant/Microsoft.DotNet.MSBuildSdkResolver.resources.dll
+lib/mono/msbuild/Current/bin/SdkVersions.Details.xml
 lib/mono/msbuild/Current/bin/Sdks/FSharp.NET.Sdk/Sdk/Sdk.OnRestore.targets
 lib/mono/msbuild/Current/bin/Sdks/FSharp.NET.Sdk/Sdk/Sdk.props
 lib/mono/msbuild/Current/bin/Sdks/FSharp.NET.Sdk/Sdk/Sdk.targets

--- a/mono/build/install.proj
+++ b/mono/build/install.proj
@@ -118,6 +118,10 @@
             <Output TaskParameter="CopiedFiles" ItemName="CopiedFiles" />
         </Copy>
 
+        <Copy SourceFiles="$(RepoRoot)\eng\Version.Details.xml" DestinationFiles="$(MSBuildInstallBinDir)\SdkVersions.Details.xml">
+            <Output TaskParameter="CopiedFiles" ItemName="CopiedFiles" />
+        </Copy>
+
         <Copy SourceFiles="@(ResourceAssemblies)"
             DestinationFiles="@(ResourceAssemblies -> '$(MSBuildInstallBinDir)\%(RecursiveDir)%(Filename)%(Extension)')">
             <Output TaskParameter="CopiedFiles" ItemName="CopiedFiles" />


### PR DESCRIPTION
```
Microsoft.NET.Sdk.Web:                  3.1.100-preview2.19522.3
Microsoft.NET.Sdk.Razor:                3.1.0-preview2.19518.7

Microsoft.NETCore.App:                  3.1.0-preview2.19522.9
Microsoft.DotNet.Cli.Runtime:           3.1.100-preview2.19522.5

NuGet.Build.Tasks:                      5.4.0-preview.3.6271
```

Based on `dotnet/toolset` `release/3.1.1xx` branch HEAD
394d0ee47de7b5af0facc3432288365866161294