### PR TITLE
[2019-08] Bump versions from dotnet/toolset at release/3.1.1xx on 11/18/2019 8:…

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
       <MicrosoftNetCompilersVersion>3.4.0-beta3-19521-01</MicrosoftNetCompilersVersion>
       <CompilerToolsVersion>$(MicrosoftNetCompilersVersion)</CompilerToolsVersion>
-      <NuGetPackageVersion>5.4.0-preview.3.6271</NuGetPackageVersion>
+      <NuGetPackageVersion>5.4.0-rtm.6292</NuGetPackageVersion>
       <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
       <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>
       <NuGetProtocolVersion Condition="'$(NuGetProtocolVersion)' == ''">$(NuGetPackageVersion)</NuGetProtocolVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,17 +7,17 @@
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="3.1.100-rtm.19565.4">
+    <Dependency Name="Microsoft.NET.Sdk" Version="3.1.100-rtm.19568.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>fc412c7e032c25a17da0e8ca4556b34897313d7c</Sha>
+      <Sha>49bbede419cf63e15c70f4b463f80e4811fe3f34</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.Razor" Version="3.1.0">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
-      <Sha>29036777e7cd2172a81c45c69e0dc257e8b8184e</Sha>
+      <Sha>806f68f84d7ecf341811e317810f9aea0e1a862e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.1.100-rtm.19566.2">
+    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.1.100-rtm.19569.1">
       <Uri>https://github.com/aspnet/websdk</Uri>
-      <Sha>6ac9d49bc28ce976ffd92539e0c14d15d5b31c3a</Sha>
+      <Sha>a1041655b92f65e492b7337786f235e0a1a4b731</Sha>
     </Dependency>
     <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.19380.1">
       <Uri>https://github.com/mono/linker</Uri>
@@ -27,9 +27,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>f830769364b45286b638a57176d4a7997dbc5237</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-rtm.19566.1">
+    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-rtm.19568.3">
       <Uri>https://github.com/dotnet/cli</Uri>
-      <Sha>56fe2cca1ad3b1e450ece97a226ce8a655d31271</Sha>
+      <Sha>cc6bdda9777fff833fe170e3006470e9409521cf</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.4.0-rtm.6292">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,17 +7,17 @@
     </Dependency>
   </ToolsetDependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="3.1.100-preview3.19553.1">
+    <Dependency Name="Microsoft.NET.Sdk" Version="3.1.100-rtm.19565.4">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>cecb7196560c8b8b732ef9c07494cac7e0745c76</Sha>
+      <Sha>fc412c7e032c25a17da0e8ca4556b34897313d7c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="3.1.0-preview3.19553.1">
+    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="3.1.0">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
-      <Sha>542a22f0b0242fc7247884b316c71e921d9711da</Sha>
+      <Sha>29036777e7cd2172a81c45c69e0dc257e8b8184e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.1.100-preview3.19554.3">
+    <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.1.100-rtm.19566.2">
       <Uri>https://github.com/aspnet/websdk</Uri>
-      <Sha>298e13fad322b0be4da015cbbc89828fcb6b818e</Sha>
+      <Sha>6ac9d49bc28ce976ffd92539e0c14d15d5b31c3a</Sha>
     </Dependency>
     <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.19380.1">
       <Uri>https://github.com/mono/linker</Uri>
@@ -27,13 +27,13 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>f830769364b45286b638a57176d4a7997dbc5237</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-preview3.19554.3">
+    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.100-rtm.19566.1">
       <Uri>https://github.com/dotnet/cli</Uri>
-      <Sha>88badb441d9477067b76916f046b8d0a212a6eca</Sha>
+      <Sha>56fe2cca1ad3b1e450ece97a226ce8a655d31271</Sha>
     </Dependency>
-    <Dependency Name="NuGet.Build.Tasks" Version="5.4.0-preview.3.6271">
+    <Dependency Name="NuGet.Build.Tasks" Version="5.4.0-rtm.6292">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
-      <Sha>c1f6915918b82c096bbd666bd9c18528f1f70630</Sha>
+      <Sha>6f8eb3a2e1db6b458451b9cfd2a4f5557769b041</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,13 +35,13 @@
   <PropertyGroup>
     <DotNetCliVersion>3.0.100</DotNetCliVersion>
     <MicrosoftNetCompilersVersion>3.4.0-beta3-19521-01</MicrosoftNetCompilersVersion>
-    <MicrosoftNETSdkVersion>3.1.100-rtm.19565.4</MicrosoftNETSdkVersion>
+    <MicrosoftNETSdkVersion>3.1.100-rtm.19568.4</MicrosoftNETSdkVersion>
     <MicrosoftNETSdkRazorVersion>3.1.0</MicrosoftNETSdkRazorVersion>
-    <MicrosoftNETSdkWebVersion>3.1.100-rtm.19566.2</MicrosoftNETSdkWebVersion>
+    <MicrosoftNETSdkWebVersion>3.1.100-rtm.19569.1</MicrosoftNETSdkWebVersion>
     <NuGetBuildTasksVersion>5.4.0-rtm.6292</NuGetBuildTasksVersion>
     <ILLinkTasksVersion>0.1.6-prerelease.19380.1</ILLinkTasksVersion>
     <MicrosoftNETCoreAppVersion>3.1.0-preview2.19521.15</MicrosoftNETCoreAppVersion>
-    <MicrosoftDotNetCliRuntimeVersion>3.1.100-rtm.19566.1</MicrosoftDotNetCliRuntimeVersion>
+    <MicrosoftDotNetCliRuntimeVersion>3.1.100-rtm.19568.3</MicrosoftDotNetCliRuntimeVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,13 +35,13 @@
   <PropertyGroup>
     <DotNetCliVersion>3.0.100</DotNetCliVersion>
     <MicrosoftNetCompilersVersion>3.4.0-beta3-19521-01</MicrosoftNetCompilersVersion>
-    <MicrosoftNETSdkVersion>3.1.100-preview3.19553.1</MicrosoftNETSdkVersion>
-    <MicrosoftNETSdkRazorVersion>3.1.0-preview3.19553.1</MicrosoftNETSdkRazorVersion>
-    <MicrosoftNETSdkWebVersion>3.1.100-preview3.19554.3</MicrosoftNETSdkWebVersion>
-    <NuGetBuildTasksVersion>5.4.0-preview.3.6271</NuGetBuildTasksVersion>
+    <MicrosoftNETSdkVersion>3.1.100-rtm.19565.4</MicrosoftNETSdkVersion>
+    <MicrosoftNETSdkRazorVersion>3.1.0</MicrosoftNETSdkRazorVersion>
+    <MicrosoftNETSdkWebVersion>3.1.100-rtm.19566.2</MicrosoftNETSdkWebVersion>
+    <NuGetBuildTasksVersion>5.4.0-rtm.6292</NuGetBuildTasksVersion>
     <ILLinkTasksVersion>0.1.6-prerelease.19380.1</ILLinkTasksVersion>
     <MicrosoftNETCoreAppVersion>3.1.0-preview2.19521.15</MicrosoftNETCoreAppVersion>
-    <MicrosoftDotNetCliRuntimeVersion>3.1.100-preview3.19554.3</MicrosoftDotNetCliRuntimeVersion>
+    <MicrosoftDotNetCliRuntimeVersion>3.1.100-rtm.19566.1</MicrosoftDotNetCliRuntimeVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">
     <!-- See https://github.com/dotnet/arcade/issues/3386

--- a/mono/build/RestoreSourcesOverrides.props
+++ b/mono/build/RestoreSourcesOverrides.props
@@ -22,7 +22,7 @@
             https://dotnet.myget.org/F/vstest/api/v3/index.json;
             https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180725-02/final/index.json;
             https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json;
-            https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-aspnet-AspNetCore-Tooling-16b0ca4a/nuget/v3/index.json
+            https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-aspnet-AspNetCore-Tooling-806f68f8/nuget/v3/index.json
         </RestoreSources>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
…34:56 PM +01:00

```
Microsoft.NET.Sdk: 3.1.100-rtm.19565.4 (from 3.1.100-preview3.19553.1)
Microsoft.NET.Sdk.Razor: 3.1.0 (from 3.1.0-preview3.19553.1)
Microsoft.NET.Sdk.Web: 3.1.100-rtm.19566.2 (from 3.1.100-preview3.19554.3)
Microsoft.DotNet.Cli.Runtime: 3.1.100-rtm.19566.1 (from 3.1.100-preview3.19554.3)
NuGet.Build.Tasks: 5.4.0-rtm.6292 (from 5.4.0-preview.3.6271)
```