### PR TITLE
Use NuGetPackageRoot in setting NuGetPackagesDir for common.props

### DIFF
--- a/mono/build/common.props
+++ b/mono/build/common.props
@@ -5,7 +5,9 @@
         <CLICommitHash>501e11d928c21608999c934f0a7078570b688c6c</CLICommitHash>
         <CLIBlobBaseURL>https://raw.githubusercontent.com/dotnet/cli/$(CLICommitHash)</CLIBlobBaseURL>
 
-        <NuGetPackagesDir>$(HOME)\.nuget\packages</NuGetPackagesDir>
+        <NuGetPackagesDir Condition="'$(NuGetPackageRoot)' != ''">$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)'))</NuGetPackagesDir>
+        <NuGetPackagesDir Condition="'$(NuGetPackageRoot)' == '' and '$(NUGET_PACKAGES)' != ''">$([MSBuild]::NormalizeDirectory('$(NUGET_PACKAGES)'))</NuGetPackagesDir>
+        <NuGetPackagesDir Condition="'$(NuGetPackageRoot)' == ''">$([MSBuild]::NormalizeDirectory('$(HOME)\.nuget\packages'))</NuGetPackagesDir>
 
         <SdkVersionsFile>$(MSBuildThisFileDirectory)\SdkVersions.txt</SdkVersionsFile>
         <DotNetOverlayDirectory>$(RepoRoot)\mono\dotnet-overlay</DotNetOverlayDirectory>


### PR DESCRIPTION
Hello! Here is a contributed patch from some local porting for mono msbuild, under the thinkum-sys pkgsrc wip contrib repository. 

This patch has been tested locally, with a build using the latest Mono source code built with a local pkgsrc installation on FreeBSD 11.2. The patch will probably be included in the work-in-progress wip/mono-msbuild port for Mono 0.08, once that port has been published to https://github.com/thinkum-sys/pkgsrc-wip 

Perhaps this patch may not be especially relevant for the build system configuration, under Azure CI. It seems to be of some use, when building the Mono MSBuild *.proj files and the MSBuild.sln directly, under some build system configurations. 

This may serve to prevent an error that was occurring after successful msbuild restore for update_bundled_bits.proj. The error appears to have occurred due to a mismatch between the pathname for NuGetPackagesDir and the pathname used by the msbuild restore, under a certain build configuration. Although the nupkg resources had been successfully restored and installed, the EnsureDependencyRestored target in the project file update_bundled_bits.proj was not locating the corresponding *.nuspec files and instead, was signaling an error.

The patch description, from the changelog:

This patch may serve to prevent a spurious error message under some
build configurations, during the restore MSBuild target for the MSBuild
project file ${WRKSRC}/mono/build/update_bundled_bits.proj

 "Tried to restore, but seems to have failed for ..."

This error message would occur from the Mono MSBuild project support file
 ${WRKSRC}/mono/build/sdks_and_nugets/deploy_from_nugets.proj
as under the MSBuild target, EnsureDependencyRestored, subsequent to
evaluation of the project support file
 ${WRKSRC}/mono/build/sdks_and_nugets/update_sdks_and_nugets.proj
namely during MSBuild evaluation of the top-level project file
 ${WRKSRC}/ mono/build/update_bundled_bits.proj

This error would occur when a *.nuspec file does not exist at a specific
pathname -- that pathname, computed as extensional to the local value of
the parameter, NuGetPackagesDir -- subsequent to the restore task under
the bootstrap msbuild environment, with update_bundled_bits.proj

The error may occur even after a successful restore, if the pathname
used in the corresponding EnsureDependencyRestored target does not match
the pathname used in the restore procedure.

The following patch endeavors to initialize the value of the
NuGetPackagesDir parameter, conditionally, with a pathname that may be
interoperable with the pathname semantics in the msbuild restore.

Subsequently, the build for mono/build/update_bundled_bits.proj may be
produced with an MSBUild parameter
  /p:NuGetPackageRoot=${MSBUILD_SRC_ROOT}/.packages

The pathname semantics applied here is roughly analogous to that used
in Microsoft.DotNet.Arcade.Sdk version 1.0.0-beta.19461.7, nupkg
resource file tools/RepoLayout.props

Additional Remarks

* The msbuild restore target may exit abnormally, per default, if
  the restore task has failed. As such, the EnsureDependencyRestored
  MSBuild target may seem redundant, in some regards.

* The NormalizeDirectory opern, as used below, adds a trailing slash to
  the string, such that may be redundant in uses of the task
  EnsureDependencyRestored

* Patch developed for mono 0.08 from local pkgsrc devo (thinkum-sys)