### PR TITLE
Versioning for ToolsVersion under MSBuild - Set ToolsVersion="4.0" in the mono sdks.csproj.

### DIFF
--- a/mono/build/sdks_and_nugets/sdks/sdks.csproj
+++ b/mono/build/sdks_and_nugets/sdks/sdks.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <Import Project="$(RepoRoot)\mono\build\common.props" />
 


### PR DESCRIPTION
Concerning the XML attributes `ToolsVersion` and `SDK` for MSBuild `Project` XML models, specifically in regards to the `ToolsVersion`  attribute for MSBuild `Project ` root element: For `ToolsVersion` it seems that the version specifiers "Current", "4.0", "3.5", and "2.0" are supported in MSBuild under VS, by default.  The .NET documentation authors have provided some additional documentation, as to how to add new toolset definitions to MSBuild. 

This patch addresses the `ToolsVersion` configured in `sdks.csproj` in Mono MSBuild, towards a concept of using a version specifier generally interoperable with MSBuild under VS tooling

Candidly, I'm concerned that it may seem -- in a practical regard -- like only a superficial change. I have not noticed any substantially different behavior from msbuild restore,  under the patched ToolsVersion value. 

If NuGet may ever start using this attribute's value during dependency resolution, perhaps it might be of some matter then.

This patch might be included in a subsequent mono-msbuild port contributed for pkgsrc wip under https://github.com/thinkum-sys/pkgsrc-wip (a work in progress) [contributed under BSD licensing terms, if it should matter]

Description from the changelog:

The MSBuild project file sdks.csproj is used in the Mono MSBuild project
file update_bundled_bits.proj in an application generally like for a
puporse of tooling, perhaps resembling of a pkgsrc bmake fetch. The
ToolsVersion specified there, although it may not have any immediate
affects for dependency resolution under NuGet, may be updated to a
version specifier supported by MSbuild.

This change is made after observing the following notification message
during msbuild for Mono, using a detailed msbuild verbosity, i.e /v:detailed

  'Project file contains ToolsVersion="15.0". This toolset may be unknown
  or missing, [ ... ]'

The original ToolsVersion value, 15.0 may appear to use a syntax and
semantics from some other .NET component.

Per documentation for MSBuild under VS 2019, "Standard and custom
Toolset configurations" (1)

> "MSBuild 16.0 includes the following standard Toolsets"
> [sic] 2.0, 3.5, 4.0, Current

(1) https://docs.microsoft.com/en-us/visualstudio/msbuild/standard-and-custom-toolset-configurations

Additional works referenced
* https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-toolset-toolsversion
* https://docs.microsoft.com/en-us/visualstudio/msbuild/overriding-toolsversion-settings

(cherry picked from commit 8dcb46940b0ee1adcf1d3b234c43164cbe61d608)