### PR TITLE
[mono] Fix RoslynCodeTaskFactory

### DIFF
--- a/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
+++ b/src/Build.UnitTests/BackEnd/TaskHost_Tests.cs
@@ -640,12 +640,10 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void TasksCanGetGlobalProperties()
         {
-            var taskFactoryName = NativeMethodsShared.IsMono ? "CodeTaskFactory" : "RoslynCodeTaskFactory";
             string projectFileContents = @"
 <Project>
-  <UsingTask TaskName='test' TaskFactory='{0}' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>".Format(taskFactoryName)
-
-+ @"<Task>
+  <UsingTask TaskName='test' TaskFactory='RoslynCodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>
+    <Task>
       <Code><![CDATA[
         var globalProperties = ((IBuildEngine6)BuildEngine).GetGlobalProperties();
 
@@ -687,12 +685,9 @@ namespace Microsoft.Build.UnitTests.BackEnd
         [Fact]
         public void TasksGetNoGlobalPropertiesIfNoneSpecified()
         {
-            var taskFactoryName = NativeMethodsShared.IsMono ? "CodeTaskFactory" : "RoslynCodeTaskFactory";
             string projectFileContents = @"
 <Project>
-  <UsingTask TaskName='test' TaskFactory='{0}' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>".Format(taskFactoryName)
-
-+ @"
+  <UsingTask TaskName='test' TaskFactory='RoslynCodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>
     <Task>
       <Code><![CDATA[
         var globalProperties = ((IBuildEngine6)BuildEngine).GetGlobalProperties();

--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Graph.UnitTests
                     <Target Name='SelfTarget'>
                     </Target>
 
-                    <UsingTask TaskName='CustomMSBuild' TaskFactory='{5}' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>
+                    <UsingTask TaskName='CustomMSBuild' TaskFactory='RoslynCodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>
                         <ParameterGroup>
                           <Projects ParameterType='Microsoft.Build.Framework.ITaskItem[]' Required='true' />
                           <Targets ParameterType='Microsoft.Build.Framework.ITaskItem[]' Required='true' />
@@ -401,8 +401,7 @@ BuildEngine5.BuildProjectFilesInParallel(
                     : string.Empty,
                 excludeReferencesFromConstraints
                     ? $"{declaredReferenceFile};{undeclaredReferenceFile}"
-                    : string.Empty,
-                NativeMethodsShared.IsMono ? "CodeTaskFactory" : "RoslynCodeTaskFactory")
+                    : string.Empty)
                 .Cleanup();
 
             File.WriteAllText(rootProjectFile, projectContents);


### PR DESCRIPTION
RoslynCodeTaskFactory: Add mono search paths for references

- On mono, we want to use mono's implementation libraries, so we try to
resolve references from mono.
- Since, we don't bundle `ref/netstandard.dll` and `ref/mscorlib.dll`,
this resolves the two assemblies from mono's assemblies.
