### PR TITLE
[mono][2019-10] Update sdks+roslyn+fixes

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -2,7 +2,7 @@
 <Project>
 
   <PropertyGroup>
-      <MicrosoftNetCompilersVersion>3.4.0-beta4-19569-03</MicrosoftNetCompilersVersion>
+      <MicrosoftNetCompilersVersion>3.5.0-beta1-19606-04</MicrosoftNetCompilersVersion>
       <CompilerToolsVersion>$(MicrosoftNetCompilersVersion)</CompilerToolsVersion>
       <NuGetPackageVersion>5.4.0-rtm.6292</NuGetPackageVersion>
       <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
       <MicrosoftNetCompilersVersion>3.5.0-beta1-19606-04</MicrosoftNetCompilersVersion>
       <CompilerToolsVersion>$(MicrosoftNetCompilersVersion)</CompilerToolsVersion>
-      <NuGetPackageVersion>5.4.0-rtm.6292</NuGetPackageVersion>
+      <NuGetPackageVersion>5.5.0-preview.1.6319</NuGetPackageVersion>
       <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
       <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>
       <NuGetProtocolVersion Condition="'$(NuGetProtocolVersion)' == ''">$(NuGetPackageVersion)</NuGetProtocolVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,7 +35,7 @@
   <!-- Toolset Dependencies -->
   <PropertyGroup>
     <DotNetCliVersion>3.0.100</DotNetCliVersion>
-    <MicrosoftNetCompilersVersion>3.4.0-beta4-19569-03</MicrosoftNetCompilersVersion>
+    <MicrosoftNetCompilersVersion>3.5.0-beta1-19606-04</MicrosoftNetCompilersVersion>
     <MicrosoftNETSdkVersion>3.1.100-rtm.19568.4</MicrosoftNETSdkVersion>
     <MicrosoftNETSdkRazorVersion>3.1.1-servicing.19575.9</MicrosoftNETSdkRazorVersion>
     <MicrosoftNETSdkWebVersion>3.1.100-rtm.19575.2</MicrosoftNETSdkWebVersion>

--- a/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
+++ b/src/Build.UnitTests/Graph/IsolateProjects_Tests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Graph.UnitTests
                     <Target Name='SelfTarget'>
                     </Target>
 
-                    <UsingTask TaskName='CustomMSBuild' TaskFactory='{5}' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>
+                    <UsingTask TaskName='CustomMSBuild' TaskFactory='RoslynCodeTaskFactory' AssemblyFile='$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll'>
                         <ParameterGroup>
                           <Projects ParameterType='Microsoft.Build.Framework.ITaskItem[]' Required='true' />
                           <Targets ParameterType='Microsoft.Build.Framework.ITaskItem[]' Required='true' />
@@ -401,8 +401,7 @@ BuildEngine5.BuildProjectFilesInParallel(
                     : string.Empty,
                 excludeReferencesFromConstraints
                     ? $"{declaredReferenceFile};{undeclaredReferenceFile}"
-                    : string.Empty,
-                NativeMethodsShared.IsMono ? "CodeTaskFactory" : "RoslynCodeTaskFactory")
+                    : string.Empty)
                 .Cleanup();
 
             File.WriteAllText(rootProjectFile, projectContents);


### PR DESCRIPTION
- This picks up a new roslyn which has `csi.exe` fixes [1][2]
- also, picks up RoslynCodeTaskFactory fixes from `xplat-master`

-- 
1. https://github.com/xamarin/md-addins/pull/6037#issuecomment-562313831
2. https://github.com/xamarin/md-addins/pull/6037#issuecomment-562326408