### PR TITLE
[mono] Allow roslyn+nuget updates from maestro

### DIFF
--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -2,9 +2,8 @@
 <Project>
 
   <PropertyGroup>
-      <MicrosoftNetCompilersVersion>3.5.0-beta1-19606-04</MicrosoftNetCompilersVersion>
+      <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersVersion)</MicrosoftNetCompilersToolsetVersion>
       <CompilerToolsVersion>$(MicrosoftNetCompilersVersion)</CompilerToolsVersion>
-      <NuGetPackageVersion>5.5.0-preview.2.6355</NuGetPackageVersion>
       <NuGetBuildTasksVersion Condition="'$(NuGetBuildTasksVersion)' == ''">$(NuGetPackageVersion)</NuGetBuildTasksVersion>
       <NuGetCommandsVersion Condition="'$(NuGetCommandsVersion)' == ''">$(NuGetPackageVersion)</NuGetCommandsVersion>
       <NuGetProtocolVersion Condition="'$(NuGetProtocolVersion)' == ''">$(NuGetPackageVersion)</NuGetProtocolVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,5 +39,9 @@
       <Uri>https://github.com/dotnet/toolset</Uri>
       <Sha>fbd8f7a1f552df1a31271e9f66f31b6567fdf433</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Net.Compilers" Version="3.5.0-beta1-19606-04" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>d2bd58c62f9104d66f415141a1a27b665c78690c</Sha>
+    </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,6 +24,7 @@
     <MicroBuildPluginsSwixBuildVersion>1.0.672</MicroBuildPluginsSwixBuildVersion>
     <MonoBuild Condition="'$(Configuration)' == 'Debug-MONO' or '$(Configuration)' == 'Release-MONO'">true</MonoBuild>
     <MicrosoftDotnetToolsetInternalVersion>3.1.200-preview.20053.4</MicrosoftDotnetToolsetInternalVersion>
+    <MicrosoftNetCompilersVersion>3.5.0-beta1-19606-04</MicrosoftNetCompilersVersion>
   </PropertyGroup>
   <!-- Repo Toolset Features -->
   <PropertyGroup Condition="'$(MonoBuild)' != 'true'">
@@ -34,7 +35,6 @@
   </PropertyGroup>
   <!-- Toolset Dependencies -->
   <PropertyGroup>
-    <MicrosoftNetCompilersVersion>3.5.0-beta1-19606-04</MicrosoftNetCompilersVersion>
     <MicrosoftNETSdkVersion>3.1.200-preview.19630.1</MicrosoftNETSdkVersion>
     <MicrosoftNETSdkRazorVersion>3.1.1-servicing.19577.2</MicrosoftNETSdkRazorVersion>
     <MicrosoftNETSdkWebVersion>3.1.100-rtm.19575.2</MicrosoftNETSdkWebVersion>

--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -73,8 +73,17 @@ Stage1Dir="$RepoRoot/stage1"
 mono_msbuild_dir="$artifacts_dir/mono-msbuild"
 msbuild_download_url="https://github.com/mono/msbuild/releases/download/0.08/mono_msbuild_6.4.0.208.zip"
 msbuild_zip="$artifacts_dir/msbuild.zip"
+roslyn_version_to_use=`grep -i MicrosoftNetCompilersVersion $ScriptRoot/Versions.props  | sed -e 's,^.*>\([^<]*\)<.*$,\1,'`
+nuget_version_to_use=`grep -i NuGetBuildTasksVersion $ScriptRoot/Versions.props  | sed -e 's,^.*>\([^<]*\)<.*$,\1,'`
 
 if [ $host_type = "mono" ] ; then
+  if [ -z "$roslyn_version_to_use" ]; then
+      echo  "Unable to find a Roslyn version to use for Microsoft.Net.Compilers.Toolset"
+      exit 1
+  fi
+  if [ -z "$nuget_version_to_use" ]; then
+      echo  "Unable to find a NuGet.Build.Tasks version to use."
+  fi
   if [ $use_system_mono == false ] ; then
       DownloadMSBuildForMono
 
@@ -82,17 +91,18 @@ if [ $host_type = "mono" ] ; then
       export _InitializeBuildToolCommand="$mono_msbuild_dir/MSBuild.dll"
       export _InitializeBuildToolFramework="net472"
 
+
       configuration="$configuration-MONO"
       extn_path="$mono_msbuild_dir/Extensions"
 
-      extra_properties=" /p:MSBuildExtensionsPath=$extn_path /p:MSBuildExtensionsPath32=$extn_path /p:MSBuildExtensionsPath64=$extn_path /p:DeterministicSourcePaths=false /fl /flp:v=diag /m:1"
+      extra_properties=" /p:MSBuildExtensionsPath=$extn_path /p:MSBuildExtensionsPath32=$extn_path /p:MSBuildExtensionsPath64=$extn_path /p:DeterministicSourcePaths=false /fl /flp:v=diag /m:1 /p:MicrosoftNetCompilersVersion=$roslyn_version_to_use /p:NuGetBuildTasksVersion=$nuget_version_to_use"
   else
       export _InitializeBuildTool="msbuild"
       export _InitializeBuildToolCommand=""
       export _InitializeBuildToolFramework="net472"
 
       configuration="$configuration-MONO"
-      extra_properties=" /fl /flp:v=diag"
+      extra_properties=" /fl /flp:v=diag /p:MicrosoftNetCompilersVersion=$roslyn_version_to_use /p:NuGetBuildTasksVersion=$nuget_version_to_use"
   fi
 fi
 
@@ -121,7 +131,7 @@ then
   export MonoTool=`which mono`
 
   extn_path="$bootstrapRoot/net472/MSBuild"
-  extra_properties=" /p:MSBuildExtensionsPath=$extn_path /p:MSBuildExtensionsPath32=$extn_path /p:MSBuildExtensionsPath64=$extn_path /p:DeterministicSourcePaths=false /fl /flp:v=diag /m:1"
+  extra_properties=" /p:MSBuildExtensionsPath=$extn_path /p:MSBuildExtensionsPath32=$extn_path /p:MSBuildExtensionsPath64=$extn_path /p:DeterministicSourcePaths=false /fl /flp:v=diag /m:1 /p:MicrosoftNetCompilersVersion=$roslyn_version_to_use /p:NuGetBuildTasksVersion=$nuget_version_to_use"
 else
   echo "Unsupported hostType ($host_type)"
   exit 1


### PR DESCRIPTION
Read roslyn+nuget versions only from `eng/Versions.props`

- maestro updates versions in `eng/Versions.props`
- but arcade requires having that available even in `eng/Packages.props`
    - I couldn't figure out a clean way to import the version from
    `eng/Versions.props`
    - So, passing that version on the command line.
- This would allow enabling roslyn+nuget updates for mono/msbuild