### PR TITLE
Revert roslyn, because of a regression

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,9 +39,9 @@
       <Uri>https://github.com/dotnet/toolset</Uri>
       <Sha>e67c4a6cfcf1c7dc3cafd40427024fb8495f2333</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers" Version="3.5.0-beta3-20114-02" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
+    <Dependency Name="Microsoft.Net.Compilers" Version="3.5.0-beta2-20074-05" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>92790e24cc2b9f9e336ed0365d610e106c01df88</Sha>
+      <Sha>c1a3db42197033d8af5e7ec76fce3461ef8f648d</Sha>
     </Dependency>
   </ProductDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <MicroBuildPluginsSwixBuildVersion>1.0.672</MicroBuildPluginsSwixBuildVersion>
     <MonoBuild Condition="'$(Configuration)' == 'Debug-MONO' or '$(Configuration)' == 'Release-MONO'">true</MonoBuild>
     <MicrosoftDotnetToolsetInternalVersion>3.1.200-preview.20114.1</MicrosoftDotnetToolsetInternalVersion>
-    <MicrosoftNetCompilersVersion>3.5.0-beta3-20114-02</MicrosoftNetCompilersVersion>
+    <MicrosoftNetCompilersVersion>3.5.0-beta2-20074-05</MicrosoftNetCompilersVersion>
   </PropertyGroup>
   <!-- Repo Toolset Features -->
   <PropertyGroup Condition="'$(MonoBuild)' != 'true'">


### PR DESCRIPTION
- See https://github.com/dotnet/roslyn/pull/41625
- the arcade bump brought in a newer roslyn that has the regression

- Suggested by @akoeplinger