### PR TITLE
[mono] Mono supports embedded pdbs too now, so don't force override to

### DIFF
--- a/src/Tasks/Microsoft.CSharp.Mono.targets
+++ b/src/Tasks/Microsoft.CSharp.Mono.targets
@@ -28,21 +28,6 @@ Copyright (C) Microsoft Corporation. All rights reserved.
             .exe.mdb
         </AllowedReferenceRelatedDebugFileExtensions>
 
-        <!--
-             csc maps `/debug:{full,pdbonly}` to `/debug:portable`
-             but if only `/debug+` is specified, then it doesn't map it.
-
-             `/debug+` is produced based on `$(DebugSymols)`, which gets a default value of 'true' in
-             Microsoft.Common.CurrentVersion.targets, with a condition:
-
-               Condition=" '$(ConfigurationName)' == 'Debug' and '$(DebugSymbols)' == '' and '$(DebugType)'=='' "
-
-             But that file is imported later, so we cannot depend on the default value of `$(DebugSumbols)` or `$(ConfigurationName)`.
-        -->
-        <_ConfigurationNameTmp>$(ConfigurationName)</_ConfigurationNameTmp>
-        <_ConfigurationNameTmp Condition="'$(ConfigurationName)' == ''">$(Configuration)</_ConfigurationNameTmp>
-
         <CscToolPath Condition="'$(CscToolPath)' == '' and '$(CscToolExe)' == 'mcs.exe'">$(MSBuildFrameworkToolsPath)</CscToolPath>
-        <DebugType Condition="'$(OS)' != 'Windows_NT' And ('$(DebugSymbols)'=='True' or ('$(DebugSymbols)'=='' And '$(_ConfigurationNameTmp)'=='Debug'))">portable</DebugType>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
.. `DebugType=portable`.

Fixes #19066 .