### PR TITLE
[mono][mono-2019-12] Update branch

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -27,19 +27,19 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>916b5cba268e1e1e803243004f4276cf40b2dda8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.300-preview.20216.1" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
+    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.1.300-preview.20227.1" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
       <Uri>https://github.com/dotnet/cli</Uri>
-      <Sha>c2dffacdbf51da60981325f7e3d91bd8ab99b85f</Sha>
+      <Sha>926678dda900534387fffd70a12973b20a3946c0</Sha>
     </Dependency>
-    <Dependency Name="NuGet.Build.Tasks" Version="5.6.0-preview.3.6558" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
+    <Dependency Name="NuGet.Build.Tasks" Version="5.6.0-rtm.6591" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
-      <Sha>863fc6bb184cccfe12caa03bea91b0ddc48843da</Sha>
+      <Sha>636570e68732c1f718ede9ca07802d7b1cc69aa0</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.Toolset.Internal" Version="3.1.300-preview.20222.9">
+    <Dependency Name="Microsoft.Dotnet.Toolset.Internal" Version="3.1.300-preview.20227.3">
       <Uri>https://github.com/dotnet/toolset</Uri>
-      <Sha>123a56af5278daf749cf997c38c89d207a2a4e3f</Sha>
+      <Sha>15d883297e1e30903dd1f9949bb5dad70fef9dff</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers" Version="3.6.0-4.20222.3" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
+    <Dependency Name="Microsoft.Net.Compilers" Version="3.6.0-4.20224.5" CoherentParentDependency="Microsoft.Dotnet.Toolset.Internal">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>3d85b48dd5e533c7d47e916e2cff417f46bdce10</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,8 +24,8 @@
     <SemanticVersioningV1>true</SemanticVersioningV1>
     <MicroBuildPluginsSwixBuildVersion>1.0.672</MicroBuildPluginsSwixBuildVersion>
     <MonoBuild Condition="'$(Configuration)' == 'Debug-MONO' or '$(Configuration)' == 'Release-MONO'">true</MonoBuild>
-    <MicrosoftDotnetToolsetInternalVersion>3.1.300-preview.20222.9</MicrosoftDotnetToolsetInternalVersion>
-    <MicrosoftNetCompilersVersion>3.6.0-4.20222.3</MicrosoftNetCompilersVersion>
+    <MicrosoftDotnetToolsetInternalVersion>3.1.300-preview.20227.3</MicrosoftDotnetToolsetInternalVersion>
+    <MicrosoftNetCompilersVersion>3.6.0-4.20224.5</MicrosoftNetCompilersVersion>
   </PropertyGroup>
   <!-- Repo Toolset Features -->
   <PropertyGroup Condition="'$(MonoBuild)' != 'true'">
@@ -39,10 +39,10 @@
     <MicrosoftNETSdkVersion>3.1.300-preview.20214.15</MicrosoftNETSdkVersion>
     <MicrosoftNETSdkRazorVersion>3.1.2</MicrosoftNETSdkRazorVersion>
     <MicrosoftNETSdkWebVersion>3.1.300-servicing.20216.7</MicrosoftNETSdkWebVersion>
-    <NuGetBuildTasksVersion>5.6.0-preview.3.6558</NuGetBuildTasksVersion>
+    <NuGetBuildTasksVersion>5.6.0-rtm.6591</NuGetBuildTasksVersion>
     <ILLinkTasksVersion>0.1.6-prerelease.19380.1</ILLinkTasksVersion>
     <MicrosoftNETCoreAppVersion>3.1.2-servicing.20067.4</MicrosoftNETCoreAppVersion>
-    <MicrosoftDotNetCliRuntimeVersion>3.1.300-preview.20216.1</MicrosoftDotNetCliRuntimeVersion>
+    <MicrosoftDotNetCliRuntimeVersion>3.1.300-preview.20227.1</MicrosoftDotNetCliRuntimeVersion>
     <DotNetCliVersion>3.1.100</DotNetCliVersion>
   </PropertyGroup>
   <Target Name="OverrideArcadeFileVersion" AfterTargets="_InitializeAssemblyVersion">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,6 +17,7 @@
   <PropertyGroup>
     <VersionPrefix>16.6.0</VersionPrefix>
     <AssemblyVersion>15.1.0.0</AssemblyVersion>
+    <DotNetFinalVersionKind>release</DotNetFinalVersionKind>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <!-- Workaround for https://github.com/dotnet/roslyn/issues/35793 -->

--- a/eng/cibuild_bootstrapped_msbuild.sh
+++ b/eng/cibuild_bootstrapped_msbuild.sh
@@ -95,7 +95,7 @@ if [ $host_type = "mono" ] ; then
       configuration="$configuration-MONO"
       extn_path="$mono_msbuild_dir/Extensions"
 
-      extra_properties=" /p:MSBuildExtensionsPath=$extn_path /p:MSBuildExtensionsPath32=$extn_path /p:MSBuildExtensionsPath64=$extn_path /p:DeterministicSourcePaths=false /fl /flp:v=diag /m:1 /p:MicrosoftNetCompilersVersion=$roslyn_version_to_use /p:NuGetBuildTasksVersion=$nuget_version_to_use"
+      extra_properties=" /p:MSBuildExtensionsPath=$extn_path /p:MSBuildExtensionsPath32=$extn_path /p:MSBuildExtensionsPath64=$extn_path /p:DeterministicSourcePaths=false /fl /flp:v=diag /m /p:MicrosoftNetCompilersVersion=$roslyn_version_to_use /p:NuGetBuildTasksVersion=$nuget_version_to_use"
   else
       export _InitializeBuildTool="msbuild"
       export _InitializeBuildToolCommand=""
@@ -133,7 +133,7 @@ then
   export MonoTool=`which mono`
 
   extn_path="$bootstrapRoot/net472/MSBuild"
-  extra_properties=" /p:MSBuildExtensionsPath=$extn_path /p:MSBuildExtensionsPath32=$extn_path /p:MSBuildExtensionsPath64=$extn_path /p:DeterministicSourcePaths=false /fl /flp:v=diag /m:1 /p:MicrosoftNetCompilersVersion=$roslyn_version_to_use /p:NuGetBuildTasksVersion=$nuget_version_to_use"
+  extra_properties=" /p:MSBuildExtensionsPath=$extn_path /p:MSBuildExtensionsPath32=$extn_path /p:MSBuildExtensionsPath64=$extn_path /p:DeterministicSourcePaths=false /fl /flp:v=diag /p:MicrosoftNetCompilersVersion=$roslyn_version_to_use /p:NuGetBuildTasksVersion=$nuget_version_to_use"
 else
   echo "Unsupported hostType ($host_type)"
   exit 1

--- a/src/MSBuild/XMake.cs
+++ b/src/MSBuild/XMake.cs
@@ -611,9 +611,8 @@ namespace Microsoft.Build.CommandLine
                     // Unfortunately /m isn't the default, and we are not yet brave enough to make it the default.
                     // However we want to give a hint to anyone who is building single proc without realizing it that there
                     // is a better way.
-                    // FIXME: remove this mono check once we have /m support
                     // Only display the message if /m isn't provided
-                    if (!NativeMethodsShared.IsMono && cpuCount == 1 && FileUtilities.IsSolutionFilename(projectFile) && verbosity > LoggerVerbosity.Minimal
+                    if (cpuCount == 1 && FileUtilities.IsSolutionFilename(projectFile) && verbosity > LoggerVerbosity.Minimal
                         && switchesNotFromAutoResponseFile[CommandLineSwitches.ParameterizedSwitch.MaxCPUCount].Length == 0
                         && switchesFromAutoResponseFile[CommandLineSwitches.ParameterizedSwitch.MaxCPUCount].Length == 0)
                     {
@@ -2343,19 +2342,6 @@ namespace Microsoft.Build.CommandLine
                     {
                         string equivalentCommandLine = commandLineSwitches.GetEquivalentCommandLineExceptProjectFile();
                         Console.WriteLine(Path.Combine(s_exePath, s_exeName) + " " + equivalentCommandLine + " " + projectFile);
-                    }
-
-                    // cpuCount > 1 not supported on mono/unix yet
-                    if (cpuCount > 1 && NativeMethodsShared.IsMono && !NativeMethodsShared.IsWindows)
-                    {
-                        cpuCount = 1;
-
-                        if (!recursing && !commandLineSwitches[CommandLineSwitches.ParameterlessSwitch.NoLogo] &&
-                            !commandLineSwitches.IsParameterizedSwitchSet(CommandLineSwitches.ParameterizedSwitch.Preprocess) &&
-                            verbosity != LoggerVerbosity.Minimal && verbosity != LoggerVerbosity.Quiet)
-                        {
-                            Console.WriteLine($"Parallel builds (/m: or /maxcpucount:) are not yet supported on Mono/Unix. Defaulting to /m:1");
-                        }
                     }
 
 #if FEATURE_XML_SCHEMA_VALIDATION


### PR DESCRIPTION
- Updates to upstream `vs16.6` branch
- Updates SDKs from `.NET Core Sdk 3.1.3xx` channel
- Enables parallel builds. The fixes were already there, but the hack preventing it from being enabled hadn't been removed.